### PR TITLE
FXSD-900 feat(session): inject $session_id and  $isFirstEventInSession with configurable timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+Version 1.2.2 (23 May, 2025)
+* [New] SDK now persists `session_id` across launches and renews it automatically after `sessionTimeout` (default 30 min, configurable).
+* [New] Added `$first_event_in_session` flag to every event’s `properties` to indicate the first event in each session.
+
+Change Log from fork base
+==========
 Version 4.8.0 (Jul 13, 2020)
 ============================
 

--- a/analytics-samples/analytics-sample/src/main/java/com/freshpaint/android/sample/SampleApp.java
+++ b/analytics-samples/analytics-sample/src/main/java/com/freshpaint/android/sample/SampleApp.java
@@ -40,8 +40,7 @@ import io.github.inflationx.viewpump.ViewPump;
 
 public class SampleApp extends Application {
 
-  // https://segment.com/segment-engineering/sources/android-test/settings/keys
-  private static final String ANALYTICS_WRITE_KEY = "82ef97c4-8367-4d61-b0be-261498e9dd13";
+  private static final String FRESHPAINT_WRITE_KEY = "cd9d9c79-642f-471f-ab76-7804593ca3c2";
 
   @Override
   public void onCreate() {
@@ -57,34 +56,18 @@ public class SampleApp extends Application {
                         .build()))
             .build());
 
-    // Initialize a new instance of the Analytics client.
+    // Initialize a new instance of the Freshpaint client.
     Freshpaint.Builder builder =
-        new Freshpaint.Builder(this, ANALYTICS_WRITE_KEY)
+        new Freshpaint.Builder(this, FRESHPAINT_WRITE_KEY)
             .trackApplicationLifecycleEvents()
             .trackAttributionInformation()
-                .connectionFactory(new ConnectionFactory() {
-                    @Override protected HttpURLConnection openConnection(String url) throws IOException {
-                        String path = Uri.parse(url).getPath();
-                        // Replace YOUR_PROXY_HOST with the address of your proxy, e.g. https://aba64da6.ngrok.io.
-                        return super.openConnection("https://057164602100797eccb988097f7fda9e.m.pipedream.net");
-                    }
-                })
-            .defaultProjectSettings(
-                new ValueMap()
-                    .putValue(
-                        "integrations",
-                        new ValueMap()
-                            .putValue(
-                                "Adjust",
-                                new ValueMap()
-                                    .putValue("appToken", "<>")
-                                    .putValue("trackAttributionData", true))))
-            .recordScreenViews();
+            .recordScreenViews()
+            .sessionTimeoutSeconds(120);
 
     // Set the initialized instance as a globally accessible instance.
     Freshpaint.setSingletonInstance(builder.build());
 
-    // Now anytime you call Analytics.with, the custom instance will be returned.
+    // Now anytime you call Freshpaint.with, the custom instance will be returned.
     Freshpaint freshpaint = Freshpaint.with(this);
 
     // If you need to know when integrations have been initialized, use the onIntegrationReady

--- a/analytics/src/main/java/io/freshpaint/android/Freshpaint.java
+++ b/analytics/src/main/java/io/freshpaint/android/Freshpaint.java
@@ -132,7 +132,7 @@ public class Freshpaint {
   // todo: use lightweight map implementation.
   private Map<String, Integration<?>> integrations;
   volatile boolean shutdown;
-  protected final long sessionTimeoutSeconds;
+  protected final int sessionTimeoutSeconds;
 
   @Private final boolean nanosecondTimestamps;
 
@@ -206,7 +206,7 @@ public class Freshpaint {
       String writeKey,
       int flushQueueSize,
       long flushIntervalInMillis,
-      long sessionTimeoutSeconds,
+      int sessionTimeoutSeconds,
       final ExecutorService analyticsExecutor,
       final boolean shouldTrackApplicationLifecycleEvents,
       CountDownLatch advertisingIdLatch,
@@ -983,7 +983,7 @@ public class Freshpaint {
     private int flushQueueSize = Utils.DEFAULT_FLUSH_QUEUE_SIZE;
     private long flushIntervalInMillis = Utils.DEFAULT_FLUSH_INTERVAL;
     private Options defaultOptions;
-    private long sessionTimeoutSeconds = Utils.DEFAULT_SESSION_TIMEOUT_SECONDS;
+    private int sessionTimeoutSeconds = Utils.DEFAULT_SESSION_TIMEOUT_SECONDS;
     private String tag;
     private LogLevel logLevel;
     private ExecutorService networkExecutor;
@@ -1089,7 +1089,7 @@ public class Freshpaint {
       return this;
     }
 
-    public Builder sessionTimeoutSeconds(long timeoutSeconds) {
+    public Builder sessionTimeoutSeconds(int timeoutSeconds) {
       if (timeoutSeconds < 0) {
         throw new IllegalArgumentException("Timeout seconds must be greater than or equal to zero.");
       }

--- a/analytics/src/main/java/io/freshpaint/android/Freshpaint.java
+++ b/analytics/src/main/java/io/freshpaint/android/Freshpaint.java
@@ -132,6 +132,7 @@ public class Freshpaint {
   // todo: use lightweight map implementation.
   private Map<String, Integration<?>> integrations;
   volatile boolean shutdown;
+  protected final long sessionTimeoutSeconds;
 
   @Private final boolean nanosecondTimestamps;
 
@@ -205,6 +206,7 @@ public class Freshpaint {
       String writeKey,
       int flushQueueSize,
       long flushIntervalInMillis,
+      long sessionTimeoutSeconds,
       final ExecutorService analyticsExecutor,
       final boolean shouldTrackApplicationLifecycleEvents,
       CountDownLatch advertisingIdLatch,
@@ -232,6 +234,7 @@ public class Freshpaint {
     this.writeKey = writeKey;
     this.flushQueueSize = flushQueueSize;
     this.flushIntervalInMillis = flushIntervalInMillis;
+    this.sessionTimeoutSeconds   = sessionTimeoutSeconds;
     this.advertisingIdLatch = advertisingIdLatch;
     this.optOut = optOut;
     this.factories = factories;
@@ -980,6 +983,7 @@ public class Freshpaint {
     private int flushQueueSize = Utils.DEFAULT_FLUSH_QUEUE_SIZE;
     private long flushIntervalInMillis = Utils.DEFAULT_FLUSH_INTERVAL;
     private Options defaultOptions;
+    private long sessionTimeoutSeconds = Utils.DEFAULT_SESSION_TIMEOUT_SECONDS;
     private String tag;
     private LogLevel logLevel;
     private ExecutorService networkExecutor;
@@ -1082,6 +1086,16 @@ public class Freshpaint {
           this.defaultOptions.setIntegration(entry.getKey(), true);
         }
       }
+      return this;
+    }
+
+    public Builder sessionTimeoutSeconds(long timeoutSeconds) {
+      if (timeoutSeconds < 0) {
+        throw new IllegalArgumentException("Timeout seconds must be greater than or equal to zero.");
+      }
+
+      this.sessionTimeoutSeconds = timeoutSeconds;
+
       return this;
     }
 
@@ -1349,6 +1363,7 @@ public class Freshpaint {
           writeKey,
           flushQueueSize,
           flushIntervalInMillis,
+          sessionTimeoutSeconds,
           executor,
           trackApplicationLifecycleEvents,
           advertisingIdLatch,

--- a/analytics/src/main/java/io/freshpaint/android/FreshpaintIntegration.java
+++ b/analytics/src/main/java/io/freshpaint/android/FreshpaintIntegration.java
@@ -150,7 +150,7 @@ class FreshpaintIntegration extends Integration<Void> {
 
   private static final String KEY_SESSION_ID = "$session_id";
   private static final String KEY_IS_FIRST_EVENT_IN_SESSION = "$is_first_event_in_session";
-  private final long sessionTimeoutSeconds;
+  private final int sessionTimeoutSeconds;
   private String currentSessionId;
   private long sessionStartedSeconds;
   private boolean isFirstEventInSession;
@@ -191,7 +191,7 @@ class FreshpaintIntegration extends Integration<Void> {
       int flushQueueSize,
       Logger logger,
       Crypto crypto,
-      long sessionTimeoutSeconds) {
+      int sessionTimeoutSeconds) {
     PayloadQueue payloadQueue;
     try {
       File folder = context.getDir("freshpaint-disk-queue", Context.MODE_PRIVATE);
@@ -228,7 +228,7 @@ class FreshpaintIntegration extends Integration<Void> {
       int flushQueueSize,
       Logger logger,
       Crypto crypto,
-      long sessionTimeoutSeconds) {
+      int sessionTimeoutSeconds) {
     this.context = context;
     this.client = client;
     this.networkExecutor = networkExecutor;

--- a/analytics/src/main/java/io/freshpaint/android/FreshpaintIntegration.java
+++ b/analytics/src/main/java/io/freshpaint/android/FreshpaintIntegration.java
@@ -61,6 +61,9 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.UUID;
+import android.util.Log;        
+import android.content.SharedPreferences;
 
 /** Entity that queues payloads on disks and uploads them periodically. */
 class FreshpaintIntegration extends Integration<Void> {
@@ -80,7 +83,8 @@ class FreshpaintIntegration extends Integration<Void> {
               freshpaint.flushIntervalInMillis,
               freshpaint.flushQueueSize,
               freshpaint.getLogger(),
-              freshpaint.crypto);
+              freshpaint.crypto,
+              freshpaint.sessionTimeoutSeconds);
         }
 
         @Override
@@ -144,6 +148,17 @@ class FreshpaintIntegration extends Integration<Void> {
 
   private final Crypto crypto;
 
+  private static final String KEY_SESSION_ID = "$session_id";
+  private static final String KEY_IS_FIRST_EVENT_IN_SESSION = "$is_first_event_in_session";
+  private final long sessionTimeoutSeconds;
+  private String currentSessionId;
+  private long sessionStartedSeconds;
+  private boolean isFirstEventInSession;
+
+  private static final String PREFS_KEY = "freshpaint_prefs";
+  private static final String PREFS_KEY_CURRENT_SESSION_ID   = "freshpaint_current_session_id";
+  private static final String PREFS_KEY_SESSION_STARTED_SECONDS = "freshpaint_session_started_seconds";
+
   /**
    * Create a {@link QueueFile} in the given folder with the given name. If the underlying file is
    * somehow corrupted, we'll delete it, and try to recreate the file. This method will throw an
@@ -175,7 +190,8 @@ class FreshpaintIntegration extends Integration<Void> {
       long flushIntervalInMillis,
       int flushQueueSize,
       Logger logger,
-      Crypto crypto) {
+      Crypto crypto,
+      long sessionTimeoutSeconds) {
     PayloadQueue payloadQueue;
     try {
       File folder = context.getDir("freshpaint-disk-queue", Context.MODE_PRIVATE);
@@ -196,7 +212,8 @@ class FreshpaintIntegration extends Integration<Void> {
         flushIntervalInMillis,
         flushQueueSize,
         logger,
-        crypto);
+        crypto,
+        sessionTimeoutSeconds);
   }
 
   FreshpaintIntegration(
@@ -210,7 +227,8 @@ class FreshpaintIntegration extends Integration<Void> {
       long flushIntervalInMillis,
       int flushQueueSize,
       Logger logger,
-      Crypto crypto) {
+      Crypto crypto,
+      long sessionTimeoutSeconds) {
     this.context = context;
     this.client = client;
     this.networkExecutor = networkExecutor;
@@ -222,6 +240,7 @@ class FreshpaintIntegration extends Integration<Void> {
     this.flushQueueSize = flushQueueSize;
     this.flushScheduler = Executors.newScheduledThreadPool(1, new Utils.AnalyticsThreadFactory());
     this.crypto = crypto;
+    this.sessionTimeoutSeconds = sessionTimeoutSeconds;
 
     freshpaintThread = new HandlerThread(FRESHPAINT_THREAD_NAME, THREAD_PRIORITY_BACKGROUND);
     freshpaintThread.start();
@@ -238,6 +257,42 @@ class FreshpaintIntegration extends Integration<Void> {
         initialDelay,
         flushIntervalInMillis,
         TimeUnit.MILLISECONDS);
+  }
+
+  private void validateOrRenewSessionWithTimeout() {
+    SharedPreferences prefs = 
+        context.getSharedPreferences(PREFS_KEY, Context.MODE_PRIVATE);
+
+    isFirstEventInSession = false;
+    currentSessionId   = prefs.getString(PREFS_KEY_CURRENT_SESSION_ID, null);
+    sessionStartedSeconds = prefs.getLong(PREFS_KEY_SESSION_STARTED_SECONDS, 0);
+    long   nowSeconds = System.currentTimeMillis() / 1_000L;
+
+    long currentSessionDuration  = nowSeconds - sessionStartedSeconds;
+
+    Log.d("Session", String.format(
+        "now=%d, started=%d, current=%d s, timeout=%d s",
+        nowSeconds,
+        sessionStartedSeconds,
+        currentSessionDuration,
+        sessionTimeoutSeconds
+    ));
+
+    if (currentSessionId == null || sessionStartedSeconds == 0 || currentSessionDuration >= sessionTimeoutSeconds) {
+      resetSession();
+    }
+  }
+
+  private void resetSession() {
+    currentSessionId   = UUID.randomUUID().toString();
+    sessionStartedSeconds = System.currentTimeMillis() / 1_000L;
+    isFirstEventInSession = true;
+
+    SharedPreferences prefs = context.getSharedPreferences(PREFS_KEY, Context.MODE_PRIVATE);
+    prefs.edit()
+      .putString(PREFS_KEY_CURRENT_SESSION_ID, currentSessionId)
+      .putLong(PREFS_KEY_SESSION_STARTED_SECONDS, sessionStartedSeconds)
+      .apply();
   }
 
   @Override
@@ -270,6 +325,7 @@ class FreshpaintIntegration extends Integration<Void> {
   }
 
   void performEnqueue(BasePayload original) {
+    validateOrRenewSessionWithTimeout();
     // Override any user provided values with anything that was bundled.
     // e.g. If user did Mixpanel: true and it was bundled, this would correctly override it with
     // false so that the server doesn't send that event as well.
@@ -283,6 +339,17 @@ class FreshpaintIntegration extends Integration<Void> {
     ValueMap payload = new ValueMap();
     payload.putAll(original);
     payload.put("integrations", combinedIntegrations);
+
+    ValueMap originalProps = payload.getValueMap("properties");
+    ValueMap eventProps    = new ValueMap();
+
+    if (originalProps != null)  eventProps.putAll(originalProps);
+    
+    eventProps.put(KEY_SESSION_ID, currentSessionId);
+    eventProps.put(KEY_IS_FIRST_EVENT_IN_SESSION, isFirstEventInSession);
+    payload.put("properties", eventProps);
+
+    Log.d("Session", payload.toString());
 
     if (payloadQueue.size() >= MAX_QUEUE_SIZE) {
       synchronized (flushLock) {

--- a/analytics/src/main/java/io/freshpaint/android/internal/Utils.java
+++ b/analytics/src/main/java/io/freshpaint/android/internal/Utils.java
@@ -83,7 +83,8 @@ public final class Utils {
   public static final int DEFAULT_FLUSH_INTERVAL = 30 * 1000; // 30s
   public static final int DEFAULT_FLUSH_QUEUE_SIZE = 20;
   public static final boolean DEFAULT_COLLECT_DEVICE_ID = true;
-
+  public static final long DEFAULT_SESSION_TIMEOUT_SECONDS = 30 * 60; // 30 minutes
+  
   /** Creates a mutable HashSet instance containing the given elements in unspecified order */
   public static <T> Set<T> newSet(T... values) {
     Set<T> set = new HashSet<>(values.length);

--- a/analytics/src/main/java/io/freshpaint/android/internal/Utils.java
+++ b/analytics/src/main/java/io/freshpaint/android/internal/Utils.java
@@ -83,7 +83,7 @@ public final class Utils {
   public static final int DEFAULT_FLUSH_INTERVAL = 30 * 1000; // 30s
   public static final int DEFAULT_FLUSH_QUEUE_SIZE = 20;
   public static final boolean DEFAULT_COLLECT_DEVICE_ID = true;
-  public static final long DEFAULT_SESSION_TIMEOUT_SECONDS = 30 * 60; // 30 minutes
+  public static final int DEFAULT_SESSION_TIMEOUT_SECONDS = 30 * 60; // 30 minutes
   
   /** Creates a mutable HashSet instance containing the given elements in unspecified order */
   public static <T> Set<T> newSet(T... values) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 GROUP=io.freshpaint.android
 
-VERSION_CODE=1121
-VERSION_NAME=1.2.1
+VERSION_CODE=1122
+VERSION_NAME=1.2.2
 
 POM_NAME=Freshpaint for Android
 POM_DESCRIPTION=Add Freshpaint to your Android App


### PR DESCRIPTION
**What does this PR do?**  
Introduces session-level tracking by adding a `"$first_event_in_session"` flag to every event’s properties.  and updates the enqueueing logic to inject both `$session_id` and `"$first_event_in_session"`.

---

**Where should the reviewer start?**  
- **`Analytics.java` / `Analytics.Builder`**  
  - Inspect the new `isFirstEventInSession()` method and how its value is wired into the integration.  
- **`FreshpaintIntegration.java`**  
  - **`validateOrRenewSessionWithTimeout()`** – verify correct timestamp handling in seconds.  
  - **`resetSession()`** – check session reset logic and persistence to `SharedPreferences`.  
  - **`performEnqueue(...)`** – ensure injection of both `"$session_id"` and `"$first_event_in_session"` into the payload.

---

**How should this be manually tested?**  
1. Build a debug APK and fire three events in sequence:  
   ```json
   // First event
   "properties": {
     "$session_id": "...",
     "$first_event_in_session": true
   }

   // Second event (immediately after)
   "$first_event_in_session": false

   // Third event (after waiting longer than sessionTimeoutSeconds)
   "$first_event_in_session": true

2. Confirm that "$session_id" remains the same for the first two events and changes on the third.

**Any background context you want to provide?**
No.

**Screenshots or screencasts (if UI/UX change)**
N/A – this is purely an SDK payload change.

**Questions:**

**Does the docs need an update?** No

**Are there any security concerns?** No

**Do we need to notify other teams?** No