### PR TITLE
Release V2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,24 @@
 Changelog
 =========
 
+Version 2.0.0 - (10 Jul, 2025)
+
+### Added
+- The SDK now automatically adds Firebase-compatible screen properties to track screen views:
+  - `event`: `screen_view`
+  - `firebase_screen`: The original screen name (from `name` or `category` field)
+  - `firebase_screen_class`: A sanitized class name (alphanumeric + "Screen" suffix)
+
+### Changed
+- Updated Gradle wrapper to 8.10.2
+- Updated Gradle properties to include modern Android settings
+- Updated dependencies to latest versions
+- Spotless lint format execution applied across codebase
+
+### Removed
+- Removed unnecessary .project and .classpath files
+
+  
 Version 1.2.3 (23 May, 2025)
 * [New] SDK now persists `session_id` across launches and renews it automatically after `sessionTimeout` (default 30 min, configurable).
 * [New] Added `$first_event_in_session` flag to every event’s `properties` to indicate the first event in each session.

--- a/analytics/src/main/java/io/freshpaint/android/integrations/ScreenPayload.java
+++ b/analytics/src/main/java/io/freshpaint/android/integrations/ScreenPayload.java
@@ -39,6 +39,8 @@ public class ScreenPayload extends BasePayload {
 
   static final String CATEGORY_KEY = "category";
   static final String NAME_KEY = "name";
+  static final String EVENT_KEY = "event";
+  static final String EVENT_VALUE = "screen_view";
   static final String PROPERTIES_KEY = "properties";
 
   @Private
@@ -68,6 +70,9 @@ public class ScreenPayload extends BasePayload {
     if (!isNullOrEmpty(category)) {
       put(CATEGORY_KEY, category);
     }
+
+    put(EVENT_KEY, EVENT_VALUE);
+
     put(PROPERTIES_KEY, properties);
   }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 GROUP=io.freshpaint.android
 
-VERSION_CODE=1122
-VERSION_NAME=1.2.3
+VERSION_CODE=2000
+VERSION_NAME=2.0.0
 
 POM_NAME=Freshpaint for Android
 POM_DESCRIPTION=Add Freshpaint to your Android App


### PR DESCRIPTION
# Release V2.0.0

This PR merges `develop` into `master` to publish version **V2.0.0** as the latest production release.

## 🔖 Key Updates

### 🆕 GA4 screen reporting compatibility
- Events now use the reserved `screen_view` event name
- Added required GA4 parameters:
  - `$firebase_screen` → `screen_name`
  - `$firebase_screen_class` → `screen_class`
- Ensures proper tracking in GA4's "Pages & Screens" report

### 🛠️ Project setup for public release
- Updated `CHANGELOG.md`
- Version bumped to **V2.0.0**

---

_For the full list of changes, see [PR #8](https://github.com/freshpaint-io/freshpaint-android/pull/8)._
