### PR TITLE
Ind 1444/deploy android

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,86 @@
+version: 2.1
+
+orbs:
+  android: circleci/android@2.3.0
+
+jobs:
+  test:
+    machine:
+      image: android:2024.11.1
+    resource_class: large
+    steps:
+      - checkout
+      - android/restore-gradle-cache
+      - android/restore-build-cache
+      - run:
+          name: Run Tests
+          command: ./gradlew test
+      - android/save-gradle-cache
+      - android/save-build-cache
+      - store_test_results:
+          path: analytics/build/test-results
+      - store_artifacts:
+          path: analytics/build/reports/tests
+
+  build:
+    machine:
+      image: android:2024.11.1
+    resource_class: large
+    steps:
+      - checkout
+      - android/restore-gradle-cache
+      - android/restore-build-cache
+      - run:
+          name: Build Release AAR
+          command: ./gradlew assembleRelease
+      - run:
+          name: Build Javadocs
+          command: ./gradlew androidJavadocs
+      - android/save-gradle-cache
+      - android/save-build-cache
+      - store_artifacts:
+          path: analytics/build/outputs/aar
+          destination: aar-files
+      - store_artifacts:
+          path: analytics/build/docs
+          destination: javadocs
+      - persist_to_workspace:
+          root: .
+          paths:
+            - analytics/build/outputs/aar/*
+            - analytics/build/docs/*
+
+  publish-release:
+    machine:
+      image: android:2024.11.1
+    resource_class: large
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - android/restore-gradle-cache
+      - run:
+          name: Publish Release to Sonatype Central
+          command: echo "Replace me with an actual publish!"
+      - android/save-gradle-cache
+
+workflows:
+  version: 2
+  build-and-publish:
+    jobs:
+      - test
+      - build:
+          requires:
+            - test
+
+      # Publish releases on master branch and tags
+      - publish-release:
+          requires:
+            - build
+          filters:
+            branches:
+              only: master
+            tags:
+              only: /^v.*/
+          context:
+            - sonatype-central

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
       - android/restore-build-cache
       - run:
           name: Run Tests
-          command: ./gradlew test
+          command: export JAVA_OPTS="--add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED" ./gradlew test
       - android/save-gradle-cache
       - android/save-build-cache
       - store_test_results:
@@ -32,10 +32,10 @@ jobs:
       - android/restore-build-cache
       - run:
           name: Build Release AAR
-          command: ./gradlew assembleRelease
+          command: export JAVA_OPTS="--add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED" ./gradlew assembleRelease
       - run:
           name: Build Javadocs
-          command: ./gradlew androidJavadocs
+          command: export JAVA_OPTS="--add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED" ./gradlew androidJavadocs
       - android/save-gradle-cache
       - android/save-build-cache
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,11 @@ jobs:
       - android/restore-gradle-cache
       - run:
           name: Publish Release to Sonatype Central
-          command: echo "Replace me with an actual publish!"
+          command: |
+            # If we use ASCII armored in memory keys, need to update this to use ORG_GRADLE_PROJECT_signingKey as an environment var
+            # See this link https://docs.gradle.org/current/userguide/signing_plugin.html#sec:in-memory-keys
+            # Then we'll also need to update `gradle-mvn-push.gradle` to use the in-memory PGP keys
+            ./gradlew -Prelease publishRelease -Psigning.keyID=$SIGNING_KEY_ID -Psigning.password=$SIGNING_KEY_PASSWORD -Psigning.=$SIGNING_KEY -PsonatypeUsername=$SONATYPE_USERNAME -PsonatypePassword=$SONATYPE_PASSWORD
       - android/save-gradle-cache
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,10 +85,10 @@ workflows:
       - publish-release:
           requires:
             - build
-#          filters:
-#            branches:
-#              only: master
-#            tags:
-#              only: /^v.*/
+          filters:
+            branches:
+              only: master
+            tags:
+              only: /^v.*/
           context:
             - sonatype-central

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,10 +85,10 @@ workflows:
       - publish-release:
           requires:
             - build
-          filters:
-            branches:
-              only: master
-            tags:
-              only: /^v.*/
+#          filters:
+#            branches:
+#              only: master
+#            tags:
+#              only: /^v.*/
           context:
             - sonatype-central

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ jobs:
             # If we use ASCII armored in memory keys, need to update this to use ORG_GRADLE_PROJECT_signingKey as an environment var
             # See this link https://docs.gradle.org/current/userguide/signing_plugin.html#sec:in-memory-keys
             # Then we'll also need to update `gradle-mvn-push.gradle` to use the in-memory PGP keys
-            ./gradlew -Prelease publishRelease -Psigning.keyID=$SIGNING_KEY_ID -Psigning.password=$SIGNING_KEY_PASSWORD -Psigning.=$SIGNING_KEY -PsonatypeUsername=$SONATYPE_USERNAME -PsonatypePassword=$SONATYPE_PASSWORD
+            ./gradlew :analytics:uploadToSonatype -PsonatypeUsername=$SONATYPE_USERNAME -PsonatypePassword=$SONATYPE_PASSWORD
       - android/save-gradle-cache
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,9 +14,9 @@ jobs:
       - android/restore-build-cache
       - run:
           name: Run Tests
-          command: |
-            export JAVA_OPTS="--add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED" 
-            ./gradlew test
+          environment:
+            JAVA_OPTS: --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
+          command: ./gradlew test
       - android/save-gradle-cache
       - android/save-build-cache
       - store_test_results:
@@ -34,12 +34,14 @@ jobs:
       - android/restore-build-cache
       - run:
           name: Build Release AAR
-          command: |
-            export JAVA_OPTS="--add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED" 
-            ./gradlew assembleRelease
+          environment:
+            JAVA_OPTS: --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
+          command: ./gradlew assembleRelease
       - run:
           name: Build Javadocs
-          command: JAVA_OPTS="--add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED" ./gradlew androidJavadocs
+          environment:
+            JAVA_OPTS: --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
+          command: ./gradlew androidJavadocs
       - android/save-gradle-cache
       - android/save-build-cache
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,8 +15,8 @@ jobs:
       - run:
           name: Run Tests
           command: |
-          export JAVA_OPTS="--add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED" 
-          ./gradlew test
+            export JAVA_OPTS="--add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED" 
+            ./gradlew test
       - android/save-gradle-cache
       - android/save-build-cache
       - store_test_results:
@@ -35,8 +35,8 @@ jobs:
       - run:
           name: Build Release AAR
           command: |
-          export JAVA_OPTS="--add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED" 
-          ./gradlew assembleRelease
+            export JAVA_OPTS="--add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED" 
+            ./gradlew assembleRelease
       - run:
           name: Build Javadocs
           command: JAVA_OPTS="--add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED" ./gradlew androidJavadocs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
       - android/restore-build-cache
       - run:
           name: Run Tests
-          command: export JAVA_OPTS="--add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED" ./gradlew test
+          command: JAVA_OPTS="--add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED" ./gradlew test
       - android/save-gradle-cache
       - android/save-build-cache
       - store_test_results:
@@ -32,10 +32,10 @@ jobs:
       - android/restore-build-cache
       - run:
           name: Build Release AAR
-          command: export JAVA_OPTS="--add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED" ./gradlew assembleRelease
+          command: JAVA_OPTS="--add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED" ./gradlew assembleRelease
       - run:
           name: Build Javadocs
-          command: export JAVA_OPTS="--add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED" ./gradlew androidJavadocs
+          command: JAVA_OPTS="--add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED" ./gradlew androidJavadocs
       - android/save-gradle-cache
       - android/save-build-cache
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,9 @@ jobs:
       - android/restore-build-cache
       - run:
           name: Run Tests
-          command: JAVA_OPTS="--add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED" ./gradlew test
+          command: |
+          export JAVA_OPTS="--add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED" 
+          ./gradlew test
       - android/save-gradle-cache
       - android/save-build-cache
       - store_test_results:
@@ -32,7 +34,9 @@ jobs:
       - android/restore-build-cache
       - run:
           name: Build Release AAR
-          command: JAVA_OPTS="--add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED" ./gradlew assembleRelease
+          command: |
+          export JAVA_OPTS="--add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED" 
+          ./gradlew assembleRelease
       - run:
           name: Build Javadocs
           command: JAVA_OPTS="--add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED" ./gradlew androidJavadocs

--- a/analytics/src/main/java/io/freshpaint/android/FreshpaintIntegration.java
+++ b/analytics/src/main/java/io/freshpaint/android/FreshpaintIntegration.java
@@ -160,6 +160,7 @@ class FreshpaintIntegration extends Integration<Void> {
       "freshpaint_session_started_seconds";
   private static final String KEY_FIREBASE_SCREEN = "firebase_screen";
   private static final String KEY_FIREBASE_SCREEN_CLASS = "firebase_screen_class";
+
   /**
    * Create a {@link QueueFile} in the given folder with the given name. If the underlying file is
    * somehow corrupted, we'll delete it, and try to recreate the file. This method will throw an
@@ -348,7 +349,7 @@ class FreshpaintIntegration extends Integration<Void> {
 
     eventProps.put(KEY_SESSION_ID, currentSessionId);
     eventProps.put(KEY_IS_FIRST_EVENT_IN_SESSION, isFirstEventInSession);
-    
+
     addScreenPropertiesIfAvailable(payload, eventProps);
 
     payload.put("properties", eventProps);
@@ -616,9 +617,9 @@ class FreshpaintIntegration extends Integration<Void> {
   }
 
   /**
-   * Adds Firebase screen properties to the event properties if a screen name is available.
-   * Extracts screen name from payload (name or category) and generates a corresponding screen class.
-   * 
+   * Adds Firebase screen properties to the event properties if a screen name is available. Extracts
+   * screen name from payload (name or category) and generates a corresponding screen class.
+   *
    * @param payload The original payload containing potential screen information
    * @param eventProps The event properties map to which screen properties will be added
    */
@@ -633,7 +634,7 @@ class FreshpaintIntegration extends Integration<Void> {
 
   /**
    * Extracts screen name from payload, trying 'name' first, then 'category'.
-   * 
+   *
    * @param payload The payload to extract screen name from
    * @return The screen name if found, null otherwise
    */
@@ -643,9 +644,9 @@ class FreshpaintIntegration extends Integration<Void> {
   }
 
   /**
-   * Generates a Firebase-compatible screen class name by removing special characters
-   * and appending "Screen" suffix.
-   * 
+   * Generates a Firebase-compatible screen class name by removing special characters and appending
+   * "Screen" suffix.
+   *
    * @param screenName The original screen name
    * @return A sanitized screen class name
    */

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ apply from: rootProject.file('gradle/versioning.gradle')
 buildscript {
   ext.kotlin_version = '2.0.21'
   repositories {
+    gradlePluginPortal()
     google()
     mavenCentral()
     maven {
@@ -11,6 +12,7 @@ buildscript {
   }
 
   dependencies {
+    classpath 'tech.medivh.plugin.publisher:tech.medivh.plugin.publisher.gradle.plugin:1.2.5'
     classpath 'com.android.tools.build:gradle:8.8.2'
     classpath 'com.diffplug.spotless:spotless-plugin-gradle:7.0.4'
     classpath 'com.getkeepsafe.dexcount:dexcount-gradle-plugin:4.0.0'
@@ -30,6 +32,7 @@ allprojects {
   apply plugin: 'idea'
 
   repositories {
+    gradlePluginPortal()
     google()
     mavenCentral()
   }

--- a/gradle.properties
+++ b/gradle.properties
@@ -31,12 +31,21 @@ org.gradle.parallel=true
 org.gradle.caching=true
 
 # Signing keys
-signing.keyId=last-8-digits-of-gpg-key
-signing.password=password-for-gpg-key
+###########################################################################3
+# This is an outdated method and can be used locally in a pinch. It allows you to specify a keyring.gpg file on a local system
+# This doesn't work well with CI, because CircleCI doesn't allow you to easily upload artifacts - so if we were to try
+# this method in Circle, we'd either need to create a gpg key on the target machine and restore on every run, or
+# ingest the key in a base64 encoded way, then emit a temporary secring.gpg file.
+###########################################################################3
+
+#signing.keyId=last-8-digits-of-gpg-key
+#signing.password=password-for-gpg-key
 # gpg --keyring secring.gpg --export-secret-keys > ~/.gnupg/secring.gpg
-signing.secretKeyRingFile=you-must-export-this-using-command-above
+#signing.secretKeyRingFile=you-must-export-this-using-command-above
 
 # Sonatype Central Credentials
 # This is not your Sonatype password, this is a generated token from https://central.sonatype.com/account
-sonatypeUsername=sonatype-user-token
-sonatypePassword=sonatype-user-token-password
+# Prefer sending these properties into the gradle command via the flag -PsonatypeUsername=your-username, that way, you
+# don't have to modify this file and add secrets to it.
+#sonatypeUsername=sonatype-user-token
+#sonatypePassword=sonatype-user-token-password

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,6 +17,7 @@ POM_LICENCE_DIST=repo
 
 POM_DEVELOPER_ID=freshpaint
 POM_DEVELOPER_NAME=Perfalytics, Inc.
+POM_DEVELOPER_EMAIL=andrew.lai@freshpaint.io
 
 # Updated JVM args for Java 17 and better performance
 org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
@@ -28,6 +29,14 @@ android.enableJetifier=true
 # Performance improvements
 org.gradle.parallel=true
 org.gradle.caching=true
-signing.keyId=
-signing.password=
-signing.secretKey=
+
+# Signing keys
+signing.keyId=last-8-digits-of-gpg-key
+signing.password=password-for-gpg-key
+# gpg --keyring secring.gpg --export-secret-keys > ~/.gnupg/secring.gpg
+signing.secretKeyRingFile=you-must-export-this-using-command-above
+
+# Sonatype Central Credentials
+# This is not your Sonatype password, this is a generated token from https://central.sonatype.com/account
+sonatypeUsername=sonatype-user-token
+sonatypePassword=sonatype-user-token-password

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@ POM_DEVELOPER_NAME=Perfalytics, Inc.
 POM_DEVELOPER_EMAIL=andrew.lai@freshpaint.io
 
 # Updated JVM args for Java 17 and better performance
-org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8 --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
 
 # Modern Android settings
 android.useAndroidX=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 GROUP=io.freshpaint.android
 
 VERSION_CODE=2000
-VERSION_NAME=2.0.0
+VERSION_NAME=2.0.4
 
 POM_NAME=Freshpaint for Android
 POM_DESCRIPTION=Add Freshpaint to your Android App

--- a/gradle/gradle-mvn-push.gradle
+++ b/gradle/gradle-mvn-push.gradle
@@ -182,6 +182,8 @@ afterEvaluate { project ->
   // Configure signing - updated for maven-publish
   signing {
     required { isReleaseBuild() && gradle.taskGraph.hasTask("publish") }
+
+    // TODO: Maybe update this so that it uses in-memory ASCII-armored keys?
     sign publishing.publications.maven
   }
 

--- a/gradle/gradle-mvn-push.gradle
+++ b/gradle/gradle-mvn-push.gradle
@@ -20,28 +20,6 @@ apply plugin: 'signing'
 version = VERSION_NAME
 group = GROUP
 
-def isReleaseBuild() {
-  return !VERSION_NAME.contains("SNAPSHOT")
-}
-
-def getReleaseRepositoryUrl() {
-  return hasProperty('RELEASE_REPOSITORY_URL') ? RELEASE_REPOSITORY_URL
-          : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
-}
-
-def getSnapshotRepositoryUrl() {
-  return hasProperty('SNAPSHOT_REPOSITORY_URL') ? SNAPSHOT_REPOSITORY_URL
-          : "https://s01.oss.sonatype.org/content/repositories/snapshots/"
-}
-
-def getRepositoryUsername() {
-  return hasProperty('NEXUS_USERNAME') ? NEXUS_USERNAME : ""
-}
-
-def getRepositoryPassword() {
-  return hasProperty('NEXUS_PASSWORD') ? NEXUS_PASSWORD : ""
-}
-
 afterEvaluate { project ->
 
   if (project.getPlugins().hasPlugin('com.android.application') ||
@@ -86,114 +64,7 @@ afterEvaluate { project ->
     }
   }
 
-  // Configure publishing - replaces uploadArchives
-  publishing {
-    publications {
-      maven(MavenPublication) {
-        groupId = GROUP
-        artifactId = POM_ARTIFACT_ID
-        version = VERSION_NAME
-
-        if (project.getPlugins().hasPlugin('com.android.application') ||
-                project.getPlugins().hasPlugin('com.android.library')) {
-          // Android library publishing
-          artifact("$buildDir/outputs/aar/${project.getName()}-release.aar")
-          artifact androidSourcesJar
-          artifact androidJavadocsJar
-        } else {
-          // Java library publishing
-          from components.java
-          artifact sourcesJar
-          artifact javadocJar
-        }
-
-        pom {
-          name = POM_NAME
-          packaging = POM_PACKAGING
-          description = POM_DESCRIPTION
-          url = POM_URL
-
-          scm {
-            url = POM_SCM_URL
-            connection = POM_SCM_CONNECTION
-            developerConnection = POM_SCM_DEV_CONNECTION
-          }
-
-          licenses {
-            license {
-              name = POM_LICENCE_NAME
-              url = POM_LICENCE_URL
-              distribution = POM_LICENCE_DIST
-            }
-          }
-
-          developers {
-            developer {
-              id = POM_DEVELOPER_ID
-              name = POM_DEVELOPER_NAME
-            }
-          }
-
-          // Add dependencies to POM (replaces automatic dependency resolution)
-          withXml {
-            def dependenciesNode = asNode().appendNode('dependencies')
-
-            def addDependencies = { configurationName ->
-              project.configurations.findByName(configurationName)?.allDependencies?.each { dep ->
-                if (dep.group != null && dep.name != null && dep.version != null && dep.name != 'unspecified') {
-                  def dependencyNode = dependenciesNode.appendNode('dependency')
-                  dependencyNode.appendNode('groupId', dep.group)
-                  dependencyNode.appendNode('artifactId', dep.name)
-                  dependencyNode.appendNode('version', dep.version)
-
-                  // Set scope based on configuration
-                  if (configurationName == 'implementation' || configurationName == 'runtime') {
-                    dependencyNode.appendNode('scope', 'runtime')
-                  } else if (configurationName == 'api' || configurationName == 'compile') {
-                    dependencyNode.appendNode('scope', 'compile')
-                  }
-                }
-              }
-            }
-
-            // Add different types of dependencies
-            addDependencies('api')
-            addDependencies('implementation')
-            addDependencies('compile') // Legacy support
-            addDependencies('runtime') // Legacy support
-          }
-        }
-      }
-    }
-
-    repositories {
-      maven {
-        name = "sonatype"
-        url = isReleaseBuild() ? getReleaseRepositoryUrl() : getSnapshotRepositoryUrl()
-
-        credentials {
-          username = getRepositoryUsername()
-          password = getRepositoryPassword()
-        }
-      }
-    }
-  }
-
   // Configure signing - updated for maven-publish
-  signing {
-    required { isReleaseBuild() && gradle.taskGraph.hasTask("publish") }
-
-    // TODO: Maybe update this so that it uses in-memory ASCII-armored keys?
-    sign publishing.publications.maven
-  }
-
-  // Legacy compatibility tasks to maintain same interface
-  task uploadArchives(dependsOn: 'publish') {
-    doLast {
-      logger.lifecycle("✅ Published ${project.name} ${VERSION_NAME} to ${isReleaseBuild() ? 'release' : 'snapshot'} repository")
-    }
-  }
-
   task install(dependsOn: 'publishToMavenLocal') {
     doLast {
       logger.lifecycle("✅ Installed ${project.name} ${VERSION_NAME} to local Maven repository")

--- a/gradle/mvn-publish.gradle
+++ b/gradle/mvn-publish.gradle
@@ -37,3 +37,27 @@ medivhPublisher {
         }
     }
 }
+
+// Signing expects a base 64 encoded version of an ascii armored PGP key
+// gpg --armor --export-secret-keys LAST-8-CHARS-OF-KEY-ID > privkey.sec.asc
+// cat privkey.sec.asc | base64
+signing {
+    def signingKeyB64 = System.getenv("SIGNING_KEY_B64")
+    def signingPassword = System.getenv("SIGNING_PASSWORD")
+    def signingKey = signingKeyB64 ? new String(Base64.decoder.decode(signingKeyB64)) : null
+
+    if (signingKey) {
+        logger.info('Signing key supplied! Using in memory PgpKeys')
+        // Only for debugging!!
+//        logger.info('**********************************')
+//        logger.lifecycle("SigningKeyB64 ${signingKeyB64.take(20)}")
+//        logger.lifecycle("SigningKey ${signingKey.take(50)}")
+//        logger.lifecycle("SigningPassword ${signingPassword}")
+//        logger.info('**********************************')
+
+        useInMemoryPgpKeys(signingKey, signingPassword)
+    } else {
+        logger.warn('Signing disabled: no SIGNING_KEY_B64 provided.')
+    }
+}
+

--- a/gradle/mvn-publish.gradle
+++ b/gradle/mvn-publish.gradle
@@ -1,133 +1,39 @@
-apply plugin: 'maven-publish'
+apply plugin: 'tech.medivh.plugin.publisher'
 apply plugin: 'signing'
 apply from: rootProject.file('gradle/versioning.gradle')
 
-def getReleaseRepositoryUrl() {
-    return hasProperty('RELEASE_REPOSITORY_URL') ? RELEASE_REPOSITORY_URL
-            : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
-}
 
-def getSnapshotRepositoryUrl() {
-    return hasProperty('SNAPSHOT_REPOSITORY_URL') ? SNAPSHOT_REPOSITORY_URL
-            : "https://s01.oss.sonatype.org/content/repositories/snapshots/"
-}
+medivhPublisher {
+    groupId = GROUP
+    artifactId = POM_ARTIFACT_ID
+    version = getVersionName()
 
-if (!hasProperty("signing.keyId")) {
-    ext["signing.keyId"] = System.getenv('SIGNING_KEY_ID')
-    ext["signing.password"] = System.getenv('SIGNING_KEY_PASSWORD')
-    ext["signing.secretKey"] = System.getenv('SIGNING_SECRET_KEY')
-    ext["NEXUS_USERNAME"] = System.getenv('NEXUS_USERNAME')
-    ext["NEXUS_PASSWORD"] = System.getenv('NEXUS_PASSWORD')
-}
+    pom {
+        name = POM_NAME
+        packaging = POM_PACKAGING
+        description = POM_DESCRIPTION
+        url = POM_URL
 
-task androidJavadocs(type: Javadoc) {
-    source = android.sourceSets.main.java.source
-    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
-    android.libraryVariants.all { variant ->
-        if (variant.name == 'release') {
-            owner.classpath += variant.javaCompileProvider.get().classpath
-        }
-    }
-    exclude '**/BuildConfig.java'
-    exclude '**/R.html', '**/R.*.html', '**/index.html'
-}
-
-task androidJavadocsJar(type: Jar, dependsOn: androidJavadocs) {
-    archiveClassifier.set('javadoc')
-    from androidJavadocs.destinationDir
-}
-
-task androidSourcesJar(type: Jar) {
-    archiveClassifier.set('sources')
-    from android.sourceSets.main.java.source
-}
-
-publishing {
-    publications {
-        release(MavenPublication) {
-            // The coordinates of the library, being set from variables that
-            // we'll set up in a moment
-            groupId GROUP
-            artifactId POM_ARTIFACT_ID
-            version getVersionName()
-
-            // Two artifacts, the `aar` and the sources
-            artifact("$buildDir/outputs/aar/${project.getName()}-release.aar")
-            artifact androidSourcesJar
-
-            // Self-explanatory metadata for the most part
-            pom {
-                name = POM_NAME
-                packaging = POM_PACKAGING
-                description = POM_DESCRIPTION
-                url = POM_URL
-
-                licenses {
-                    license {
-                        name = POM_LICENCE_NAME
-                        url = POM_LICENCE_URL
-                        distribution = POM_LICENCE_DIST
-                    }
-                }
-
-                developers {
-                    developer {
-                        id = POM_DEVELOPER_ID
-                        name = POM_DEVELOPER_NAME
-                    }
-                }
-
-                scm {
-                    url = POM_SCM_URL
-                    connection = POM_SCM_CONNECTION
-                    developerConnection = POM_SCM_DEV_CONNECTION
-                }
-                // A slight fix so that the generated POM will include any transitive dependencies
-                // that the library builds upon
-                withXml {
-                    def dependenciesNode = asNode().appendNode('dependencies')
-
-                    project.configurations.implementation.allDependencies.each {
-                        def dependencyNode = dependenciesNode.appendNode('dependency')
-                        dependencyNode.appendNode('groupId', it.group)
-                        dependencyNode.appendNode('artifactId', it.name)
-                        dependencyNode.appendNode('version', it.version)
-                    }
-                }
+        licenses {
+            license {
+                name = POM_LICENCE_NAME
+                url = POM_LICENCE_URL
+                distribution = POM_LICENCE_DIST
             }
         }
-    }
-    repositories {
-        maven {
-            name = "sonatype"
 
-            // You only need this if you want to publish snapshots, otherwise just set the URL
-            // to the release repo directly
-            url = version.endsWith('SNAPSHOT') ? getSnapshotRepositoryUrl() : getReleaseRepositoryUrl()
-
-            // The username and password we've fetched earlier
-            if (!getUrl().toString().startsWith("file:/")) {
-                credentials {
-                    username findProperty("NEXUS_USERNAME")
-                    password findProperty("NEXUS_PASSWORD")
-                }
+        developers {
+            developer {
+                id = POM_DEVELOPER_ID
+                name = POM_DEVELOPER_NAME
+                email = POM_DEVELOPER_EMAIL
             }
+        }
+
+        scm {
+            url = POM_SCM_URL
+            connection = POM_SCM_CONNECTION
+            developerConnection = POM_SCM_DEV_CONNECTION
         }
     }
 }
-
-signing {
-    useInMemoryPgpKeys(
-        findProperty("signing.keyId"),
-        findProperty("signing.secretKey"),
-        findProperty("signing.password")
-    )
-    sign publishing.publications.release
-}
-
-afterEvaluate {
-    androidJavadocs.classpath += project.android.libraryVariants.toList().first().javaCompile.classpath
-}
-
-publish.dependsOn build
-publishToMavenLocal.dependsOn build

--- a/gradle/mvn-publish.gradle
+++ b/gradle/mvn-publish.gradle
@@ -57,7 +57,10 @@ signing {
 
         useInMemoryPgpKeys(signingKey, signingPassword)
     } else {
-        logger.warn('Signing disabled: no SIGNING_KEY_B64 provided.')
+        logger.warn('**********************************')
+        logger.warn('Signing failed: no SIGNING_KEY_B64 provided')
+        logger.warn('Please provide SIGNING_KEY_B64 and SIGNING_PASSWORD as environment variables')
+        logger.warn('**********************************')
     }
 }
 

--- a/gradle/versioning.gradle
+++ b/gradle/versioning.gradle
@@ -3,7 +3,7 @@ def isReleaseBuild() {
 }
 
 def getVersionName() { // If not release build add SNAPSHOT suffix
-    return isReleaseBuild() ? VERSION_NAME : VERSION_NAME+"-SNAPSHOT"
+    return VERSION_NAME
 }
 
 ext {


### PR DESCRIPTION
This is a working implementation! See this [job for evidence](https://app.circleci.com/pipelines/github/freshpaint-io/freshpaint-android/9/workflows/6fb5a4ca-e08d-4c2c-aaf2-650aff1c2e42/jobs/18)

Due to limitations in CircleCI (not being able to supply a keyring file easily), I migrated to using the `inMemoryPgpKeys`, which are supplied via environment variable arguments.

With those variables set `SIGNING_KEY_B64`, `SIGNING_PASSWORD`, `SONATYPE_USERNAME`, `SONATYPE_PASSWORD`, running the following command will build and deploy

```
./gradlew :analytics:build

# The -P flags create gradle properties from the environment variables. 
./gradlew :analytics:uploadToSonatype -PsonatypeUsername=$SONATYPE_USERNAME -PsonatypePassword=$SONATYPE_PASSWORD

```

**Deployment workflow**
- Add a tag on the Master branch. This tag should have the prefix `v.*` (e.g. v.2.0.10). This should trigger the "publish" workflow in CICD.

**Limitations:**
- Today, Sonatype central doesn't have the ability to provision account-level tokens - each user can generate exactly one token. This makes it impossible to create a reasonable service account on behalf of Freshpaint - we would need to share login credentials to that account, which would be a pain to manage. Today, to get around that, I am using my own Sonatype user credentials and my own GPG key for signing.