### PR TITLE
Chore: FRP-13 - Update Android Dependencies.

### DIFF
--- a/analytics-samples/analytics-sample/build.gradle
+++ b/analytics-samples/analytics-sample/build.gradle
@@ -39,17 +39,18 @@ dependencies {
   implementation project(':analytics-wear')
 
   implementation 'io.github.inflationx:calligraphy3:3.1.1'
-  implementation 'io.github.inflationx:viewpump:2.0.3'
-  implementation 'com.jakewharton:butterknife:10.2.1'
-  annotationProcessor 'com.jakewharton:butterknife-compiler:10.2.1'
+  implementation 'io.github.inflationx:viewpump:2.1.1'
+  implementation 'com.jakewharton:butterknife:10.2.3'
+  annotationProcessor 'com.jakewharton:butterknife-compiler:10.2.3'
 
-  androidTestImplementation 'com.squareup.retrofit2:retrofit:2.9.0'
-  androidTestImplementation 'com.squareup.retrofit2:converter-moshi:2.8.1'
+  androidTestImplementation 'com.squareup.retrofit2:retrofit:3.0.0'
+  androidTestImplementation 'com.squareup.retrofit2:converter-moshi:3.0.0'
 
   androidTestImplementation rootProject.ext.deps.supportAnnotations
-  androidTestImplementation 'androidx.test:runner:1.6.2'
-  androidTestImplementation 'androidx.test:rules:1.6.1'
+  androidTestImplementation 'androidx.test:runner:1.7.0'
+  androidTestImplementation 'androidx.test:rules:1.7.0'
   androidTestImplementation 'com.segment.backo:backo:1.0.0'
 
-  androidTestImplementation 'org.assertj:assertj-core:3.23.1'
+    // Bumped to a stable version: Cannot bump forward due to bytebuddy.
+  androidTestImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/analytics/build.gradle
+++ b/analytics/build.gradle
@@ -38,8 +38,8 @@ dependencies {
   api rootProject.ext.deps.supportAnnotations
 
   // Conservative lifecycle dependencies compatible with AGP 7.3.1
-  implementation 'androidx.lifecycle:lifecycle-process:2.9.1'
-  implementation 'androidx.lifecycle:lifecycle-common-java8:2.9.1'
+  implementation 'androidx.lifecycle:lifecycle-process:2.10.0'
+  implementation 'androidx.lifecycle:lifecycle-common-java8:2.10.0'
 
   testImplementation 'junit:junit:4.13.2'
   testImplementation('org.robolectric:robolectric:3.5') {
@@ -47,9 +47,10 @@ dependencies {
     exclude group: 'org.apache.httpcomponents', module: 'httpclient'
   }
   testImplementation 'com.squareup.assertj:assertj-android:1.2.0'
-  testImplementation 'org.mockito:mockito-core:1.10.19'
-  testImplementation 'com.squareup.okio:okio:1.14.0'
-  testImplementation 'com.squareup.okhttp:mockwebserver:2.7.4'
+  // Not bumping to 5.21.0 because mockito requires bitebuddy and Java 24, which breaks the app.
+  testImplementation 'org.mockito:mockito-core:5.1.0'
+  testImplementation 'com.squareup.okio:okio:3.16.4'
+  testImplementation 'com.squareup.okhttp:mockwebserver:2.7.5'
   testImplementation 'com.squareup.burst:burst-junit4:1.2.0'
 
   // We're intentionally on assertj 1.7.1 as the latest (3.8.0 as of 22/12/2017) is not compatible
@@ -57,8 +58,8 @@ dependencies {
   //noinspection GradleDependency
   testImplementation 'org.assertj:assertj-core:1.7.1'
 
-  // Conservative assertj version
-  testImplementation 'org.assertj:assertj-core:3.23.1'
+  // Conservative assertj version compatible with Kotlin 2.0.21
+  testImplementation 'org.assertj:assertj-core:3.26.3'
 
   // Conservative core dependencies
   implementation "androidx.core:core-ktx:1.16.0"

--- a/analytics/build.gradle
+++ b/analytics/build.gradle
@@ -49,7 +49,8 @@ dependencies {
   testImplementation 'com.squareup.assertj:assertj-android:1.2.0'
   // Not bumping to 5.21.0 because mockito requires bitebuddy and Java 24, which breaks the app.
   testImplementation 'org.mockito:mockito-core:5.1.0'
-  testImplementation 'com.squareup.okio:okio:3.16.4'
+  // Pinned to 3.9.1 for Kotlin 2.0.21 compatibility (3.16.4 requires Kotlin 2.2.0)
+  testImplementation 'com.squareup.okio:okio:3.9.1'
   testImplementation 'com.squareup.okhttp:mockwebserver:2.7.5'
   testImplementation 'com.squareup.burst:burst-junit4:1.2.0'
 

--- a/analytics/src/test/java/io/freshpaint/android/AnalyticsBuilderTest.java
+++ b/analytics/src/test/java/io/freshpaint/android/AnalyticsBuilderTest.java
@@ -27,7 +27,7 @@ import static android.Manifest.permission.INTERNET;
 import static android.content.pm.PackageManager.PERMISSION_DENIED;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;

--- a/analytics/src/test/java/io/freshpaint/android/AnalyticsTest.java
+++ b/analytics/src/test/java/io/freshpaint/android/AnalyticsTest.java
@@ -26,7 +26,7 @@ package io.freshpaint.android;
 import static android.content.Context.MODE_PRIVATE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
-import static org.mockito.Matchers.*;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -70,6 +70,7 @@ import org.assertj.core.api.Assertions;
 import org.assertj.core.data.MapEntry;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeMatcher;
+import org.mockito.ArgumentMatcher;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -215,7 +216,7 @@ public class AnalyticsTest {
             argThat(
                 new TestUtils.NoDescriptionMatcher<IdentifyPayload>() {
                   @Override
-                  protected boolean matchesSafely(IdentifyPayload item) {
+                  public boolean matches(IdentifyPayload item) {
                     return item.userId().equals("prateek")
                         && item.traits().username().equals("f2prateek");
                   }
@@ -238,7 +239,7 @@ public class AnalyticsTest {
             argThat(
                 new TestUtils.NoDescriptionMatcher<IdentifyPayload>() {
                   @Override
-                  protected boolean matchesSafely(IdentifyPayload item) {
+                  public boolean matches(IdentifyPayload item) {
                     // Exercises a bug where payloads didn't pick up userId in identify correctly.
                     // https://github.com/segmentio/analytics-android/issues/169
                     return item.userId().equals("foo");
@@ -272,7 +273,7 @@ public class AnalyticsTest {
             argThat(
                 new TestUtils.NoDescriptionMatcher<GroupPayload>() {
                   @Override
-                  protected boolean matchesSafely(GroupPayload item) {
+                  public boolean matches(GroupPayload item) {
                     return item.groupId().equals("segment") && item.traits().employees() == 42;
                   }
                 }));
@@ -300,7 +301,7 @@ public class AnalyticsTest {
             argThat(
                 new TestUtils.NoDescriptionMatcher<TrackPayload>() {
                   @Override
-                  protected boolean matchesSafely(TrackPayload payload) {
+                  public boolean matches(TrackPayload payload) {
                     return payload.event().equals("wrote tests")
                         && //
                         payload.properties().url().equals("github.com");
@@ -333,7 +334,7 @@ public class AnalyticsTest {
             argThat(
                 new TestUtils.NoDescriptionMatcher<ScreenPayload>() {
                   @Override
-                  protected boolean matchesSafely(ScreenPayload payload) {
+                  public boolean matches(ScreenPayload payload) {
                     return payload.name().equals("saw tests")
                         && //
                         payload.category().equals("android")
@@ -373,7 +374,7 @@ public class AnalyticsTest {
             argThat(
                 new TestUtils.NoDescriptionMatcher<TrackPayload>() {
                   @Override
-                  protected boolean matchesSafely(TrackPayload payload) {
+                  public boolean matches(TrackPayload payload) {
                     return payload.context().get("from_tests") == Boolean.TRUE;
                   }
                 }));
@@ -407,7 +408,7 @@ public class AnalyticsTest {
             argThat(
                 new TestUtils.NoDescriptionMatcher<TrackPayload>() {
                   @Override
-                  protected boolean matchesSafely(TrackPayload payload) {
+                  public boolean matches(TrackPayload payload) {
                     return payload.event().equals("foo");
                   }
                 }));
@@ -437,7 +438,7 @@ public class AnalyticsTest {
             argThat(
                 new TestUtils.NoDescriptionMatcher<TrackPayload>() {
                   @Override
-                  protected boolean matchesSafely(TrackPayload payload) {
+                  public boolean matches(TrackPayload payload) {
                     return payload.event().equals("foo");
                   }
                 }));
@@ -548,7 +549,7 @@ public class AnalyticsTest {
             argThat(
                 new TestUtils.NoDescriptionMatcher<TrackPayload>() {
                   @Override
-                  protected boolean matchesSafely(TrackPayload payload) {
+                  public boolean matches(TrackPayload payload) {
                     return payload.event().equals("foo");
                   }
                 }));
@@ -621,14 +622,11 @@ public class AnalyticsTest {
     verify(traitsCache)
         .set(
             argThat(
-                new TypeSafeMatcher<Traits>() {
+                new ArgumentMatcher<Traits>() {
                   @Override
-                  protected boolean matchesSafely(Traits traits) {
+                  public boolean matches(Traits traits) {
                     return !Utils.isNullOrEmpty(traits.anonymousId());
                   }
-
-                  @Override
-                  public void describeTo(Description description) {}
                 }));
     assertThat(analyticsContext.traits()).hasSize(1).containsKey("anonymousId");
   }
@@ -782,7 +780,7 @@ public class AnalyticsTest {
             argThat(
                 new TestUtils.NoDescriptionMatcher<LifecycleObserver>() {
                   @Override
-                  protected boolean matchesSafely(LifecycleObserver item) {
+                  public boolean matches(LifecycleObserver item) {
                     callback.set((DefaultLifecycleObserver) item);
                     return true;
                   }
@@ -828,7 +826,7 @@ public class AnalyticsTest {
             argThat(
                 new TestUtils.NoDescriptionMatcher<TrackPayload>() {
                   @Override
-                  protected boolean matchesSafely(TrackPayload payload) {
+                  public boolean matches(TrackPayload payload) {
                     return payload.event().equals("Application Installed")
                         && //
                         payload.properties().getString("version").equals("1.0.0")
@@ -870,7 +868,7 @@ public class AnalyticsTest {
             argThat(
                 new TestUtils.NoDescriptionMatcher<LifecycleObserver>() {
                   @Override
-                  protected boolean matchesSafely(LifecycleObserver item) {
+                  public boolean matches(LifecycleObserver item) {
                     callback.set((DefaultLifecycleObserver) item);
                     return true;
                   }
@@ -916,7 +914,7 @@ public class AnalyticsTest {
             argThat(
                 new TestUtils.NoDescriptionMatcher<TrackPayload>() {
                   @Override
-                  protected boolean matchesSafely(TrackPayload payload) {
+                  public boolean matches(TrackPayload payload) {
                     return payload.event().equals("Application Updated")
                         && //
                         payload.properties().getString("previous_version").equals("1.0.0")
@@ -942,7 +940,7 @@ public class AnalyticsTest {
             argThat(
                 new TestUtils.NoDescriptionMatcher<Application.ActivityLifecycleCallbacks>() {
                   @Override
-                  protected boolean matchesSafely(Application.ActivityLifecycleCallbacks item) {
+                  public boolean matches(Application.ActivityLifecycleCallbacks item) {
                     callback.set(item);
                     return true;
                   }
@@ -997,7 +995,7 @@ public class AnalyticsTest {
             argThat(
                 new TestUtils.NoDescriptionMatcher<ScreenPayload>() {
                   @Override
-                  protected boolean matchesSafely(ScreenPayload payload) {
+                  public boolean matches(ScreenPayload payload) {
                     return payload.name().equals("Foo");
                   }
                 }));
@@ -1015,7 +1013,7 @@ public class AnalyticsTest {
             argThat(
                 new TestUtils.NoDescriptionMatcher<Application.ActivityLifecycleCallbacks>() {
                   @Override
-                  protected boolean matchesSafely(Application.ActivityLifecycleCallbacks item) {
+                  public boolean matches(Application.ActivityLifecycleCallbacks item) {
                     callback.set(item);
                     return true;
                   }
@@ -1069,7 +1067,7 @@ public class AnalyticsTest {
             argThat(
                 new TestUtils.NoDescriptionMatcher<TrackPayload>() {
                   @Override
-                  protected boolean matchesSafely(TrackPayload payload) {
+                  public boolean matches(TrackPayload payload) {
                     return payload.event().equals("Deep Link Opened")
                         && payload.properties().getString("url").equals(expectedUrl)
                         && payload.properties().getString("gclid").equals("abcd")
@@ -1090,7 +1088,7 @@ public class AnalyticsTest {
             argThat(
                 new TestUtils.NoDescriptionMatcher<Application.ActivityLifecycleCallbacks>() {
                   @Override
-                  protected boolean matchesSafely(Application.ActivityLifecycleCallbacks item) {
+                  public boolean matches(Application.ActivityLifecycleCallbacks item) {
                     callback.set(item);
                     return true;
                   }
@@ -1144,7 +1142,7 @@ public class AnalyticsTest {
             argThat(
                 new TestUtils.NoDescriptionMatcher<TrackPayload>() {
                   @Override
-                  protected boolean matchesSafely(TrackPayload payload) {
+                  public boolean matches(TrackPayload payload) {
                     return payload.event().equals("Deep Link Opened")
                         && payload.properties().getString("url").equals(expectedUrl)
                         && payload.properties().getString("gclid").equals("abcd")
@@ -1165,7 +1163,7 @@ public class AnalyticsTest {
             argThat(
                 new TestUtils.NoDescriptionMatcher<Application.ActivityLifecycleCallbacks>() {
                   @Override
-                  protected boolean matchesSafely(Application.ActivityLifecycleCallbacks item) {
+                  public boolean matches(Application.ActivityLifecycleCallbacks item) {
                     callback.set(item);
                     return true;
                   }
@@ -1214,7 +1212,7 @@ public class AnalyticsTest {
             argThat(
                 new TestUtils.NoDescriptionMatcher<TrackPayload>() {
                   @Override
-                  protected boolean matchesSafely(TrackPayload payload) {
+                  public boolean matches(TrackPayload payload) {
                     return payload.event().equals("Deep Link Opened");
                   }
                 }));
@@ -1232,7 +1230,7 @@ public class AnalyticsTest {
             argThat(
                 new TestUtils.NoDescriptionMatcher<Application.ActivityLifecycleCallbacks>() {
                   @Override
-                  protected boolean matchesSafely(Application.ActivityLifecycleCallbacks item) {
+                  public boolean matches(Application.ActivityLifecycleCallbacks item) {
                     callback.set(item);
                     return true;
                   }
@@ -1284,7 +1282,7 @@ public class AnalyticsTest {
             argThat(
                 new TestUtils.NoDescriptionMatcher<TrackPayload>() {
                   @Override
-                  protected boolean matchesSafely(TrackPayload payload) {
+                  public boolean matches(TrackPayload payload) {
                     return payload.event().equals("Deep Link Opened");
                   }
                 }));
@@ -1302,7 +1300,7 @@ public class AnalyticsTest {
             argThat(
                 new TestUtils.NoDescriptionMatcher<Application.ActivityLifecycleCallbacks>() {
                   @Override
-                  protected boolean matchesSafely(Application.ActivityLifecycleCallbacks item) {
+                  public boolean matches(Application.ActivityLifecycleCallbacks item) {
                     callback.set(item);
                     return true;
                   }
@@ -1378,7 +1376,7 @@ public class AnalyticsTest {
             argThat(
                 new TestUtils.NoDescriptionMatcher<LifecycleObserver>() {
                   @Override
-                  protected boolean matchesSafely(LifecycleObserver item) {
+                  public boolean matches(LifecycleObserver item) {
                     callback.set((DefaultLifecycleObserver) item);
                     return true;
                   }
@@ -1425,7 +1423,7 @@ public class AnalyticsTest {
             argThat(
                 new TestUtils.NoDescriptionMatcher<TrackPayload>() {
                   @Override
-                  protected boolean matchesSafely(TrackPayload payload) {
+                  public boolean matches(TrackPayload payload) {
                     return payload.event().equals("Application Opened")
                         && payload.properties().getString("version").equals("1.0.0")
                         && payload.properties().getString("build").equals(String.valueOf(100))
@@ -1446,7 +1444,7 @@ public class AnalyticsTest {
             argThat(
                 new TestUtils.NoDescriptionMatcher<LifecycleObserver>() {
                   @Override
-                  protected boolean matchesSafely(LifecycleObserver item) {
+                  public boolean matches(LifecycleObserver item) {
                     callback.set((DefaultLifecycleObserver) item);
                     return true;
                   }
@@ -1498,7 +1496,7 @@ public class AnalyticsTest {
             argThat(
                 new TestUtils.NoDescriptionMatcher<TrackPayload>() {
                   @Override
-                  protected boolean matchesSafely(TrackPayload payload) {
+                  public boolean matches(TrackPayload payload) {
                     return payload.event().equals("Application Backgrounded");
                   }
                 }));
@@ -1516,7 +1514,7 @@ public class AnalyticsTest {
             argThat(
                 new TestUtils.NoDescriptionMatcher<LifecycleObserver>() {
                   @Override
-                  protected boolean matchesSafely(LifecycleObserver item) {
+                  public boolean matches(LifecycleObserver item) {
                     callback.set((DefaultLifecycleObserver) item);
                     return true;
                   }
@@ -1565,7 +1563,7 @@ public class AnalyticsTest {
             argThat(
                 new TestUtils.NoDescriptionMatcher<TrackPayload>() {
                   @Override
-                  protected boolean matchesSafely(TrackPayload payload) {
+                  public boolean matches(TrackPayload payload) {
                     return payload.event().equals("Application Backgrounded");
                   }
                 }));
@@ -1575,7 +1573,7 @@ public class AnalyticsTest {
             argThat(
                 new TestUtils.NoDescriptionMatcher<TrackPayload>() {
                   @Override
-                  protected boolean matchesSafely(TrackPayload payload) {
+                  public boolean matches(TrackPayload payload) {
                     return payload.event().equals("Application Opened")
                         && payload.properties().getBoolean("from_background", false);
                   }
@@ -1596,7 +1594,7 @@ public class AnalyticsTest {
             argThat(
                 new TestUtils.NoDescriptionMatcher<Application.ActivityLifecycleCallbacks>() {
                   @Override
-                  protected boolean matchesSafely(Application.ActivityLifecycleCallbacks item) {
+                  public boolean matches(Application.ActivityLifecycleCallbacks item) {
                     registeredCallback.set(item);
                     return true;
                   }
@@ -1607,7 +1605,7 @@ public class AnalyticsTest {
             argThat(
                 new TestUtils.NoDescriptionMatcher<Application.ActivityLifecycleCallbacks>() {
                   @Override
-                  protected boolean matchesSafely(Application.ActivityLifecycleCallbacks item) {
+                  public boolean matches(Application.ActivityLifecycleCallbacks item) {
                     unregisteredCallback.set(item);
                     return true;
                   }
@@ -1692,7 +1690,7 @@ public class AnalyticsTest {
             argThat(
                 new TestUtils.NoDescriptionMatcher<LifecycleObserver>() {
                   @Override
-                  protected boolean matchesSafely(LifecycleObserver item) {
+                  public boolean matches(LifecycleObserver item) {
                     registeredCallback.set((DefaultLifecycleObserver) item);
                     return true;
                   }
@@ -1703,7 +1701,7 @@ public class AnalyticsTest {
             argThat(
                 new TestUtils.NoDescriptionMatcher<LifecycleObserver>() {
                   @Override
-                  protected boolean matchesSafely(LifecycleObserver item) {
+                  public boolean matches(LifecycleObserver item) {
                     unregisteredCallback.set((DefaultLifecycleObserver) item);
                     return true;
                   }

--- a/analytics/src/test/java/io/freshpaint/android/DestinationMiddlewareTest.java
+++ b/analytics/src/test/java/io/freshpaint/android/DestinationMiddlewareTest.java
@@ -25,8 +25,7 @@ package io.freshpaint.android;
 
 import static io.freshpaint.android.TestUtils.grantPermission;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyObject;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -240,7 +239,7 @@ public class DestinationMiddlewareTest {
     freshpaint.track("foo");
 
     assertThat(payloadRef.get().event()).isEqualTo("foo");
-    verify(integrationFoo, never()).track(anyObject()); // validate event does not go through
+    verify(integrationFoo, never()).track(any()); // validate event does not go through
     verify(integrationBar).track(payloadRef.get()); // validate event goes through
   }
 

--- a/analytics/src/test/java/io/freshpaint/android/FreshpaintIntegrationTest.java
+++ b/analytics/src/test/java/io/freshpaint/android/FreshpaintIntegrationTest.java
@@ -32,15 +32,15 @@ import static io.freshpaint.android.TestUtils.TRACK_PAYLOAD_JSON;
 import static io.freshpaint.android.TestUtils.mockApplication;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyMap;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
@@ -202,7 +202,7 @@ public class FreshpaintIntegrationTest {
     for (int i = 0; i < 4; i++) {
       freshpaintIntegration.performEnqueue(TRACK_PAYLOAD);
     }
-    verifyZeroInteractions(client);
+    verifyNoInteractions(client);
     // Only the last enqueue should trigger an upload.
     freshpaintIntegration.performEnqueue(TRACK_PAYLOAD);
 
@@ -295,7 +295,7 @@ public class FreshpaintIntegrationTest {
 
     freshpaintIntegration.submitFlush();
 
-    verifyZeroInteractions(context);
+    verifyNoInteractions(context);
     verify(client, never()).upload();
   }
 

--- a/analytics/src/test/java/io/freshpaint/android/TestUtils.java
+++ b/analytics/src/test/java/io/freshpaint/android/TestUtils.java
@@ -25,9 +25,9 @@ package io.freshpaint.android;
 
 import static android.Manifest.permission.INTERNET;
 import static android.content.pm.PackageManager.PERMISSION_GRANTED;
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.argThat;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -45,6 +45,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeMatcher;
+import org.mockito.ArgumentMatcher;
 import org.json.JSONObject;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -156,32 +157,6 @@ public final class TestUtils {
     throw new AssertionError("no instances");
   }
 
-  public static <K, V> Map<K, V> mapEq(Map<K, V> expected) {
-    return argThat(new MapMatcher<>(expected));
-  }
-
-  private static class MapMatcher<K, V> extends TypeSafeMatcher<Map<K, V>> {
-
-    private final Map<K, V> expected;
-
-    MapMatcher(Map<K, V> expected) {
-      this.expected = expected;
-    }
-
-    @Override
-    public boolean matchesSafely(Map<K, V> map) {
-      return expected.equals(map);
-    }
-
-    @Override
-    public void describeTo(Description description) {
-      description.appendText(expected.toString());
-    }
-  }
-
-  public static JSONObject jsonEq(JSONObject expected) {
-    return argThat(new JSONObjectMatcher(expected));
-  }
 
   private static class JSONObjectMatcher extends TypeSafeMatcher<JSONObject> {
 
@@ -243,9 +218,9 @@ public final class TestUtils {
     shadowApp.grantPermissions(permission);
   }
 
-  public abstract static class NoDescriptionMatcher<T> extends TypeSafeMatcher<T> {
+  public abstract static class NoDescriptionMatcher<T> implements ArgumentMatcher<T> {
 
     @Override
-    public void describeTo(Description description) {}
+    public abstract boolean matches(T argument);
   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,7 @@ buildscript {
   dependencies {
     classpath 'tech.medivh.plugin.publisher:tech.medivh.plugin.publisher.gradle.plugin:1.2.5'
     classpath 'com.android.tools.build:gradle:8.8.2'
+    // Cannot bump: Breaks functionality.
     classpath 'com.diffplug.spotless:spotless-plugin-gradle:7.0.4'
     classpath 'com.getkeepsafe.dexcount:dexcount-gradle-plugin:4.0.0'
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
@@ -59,7 +60,7 @@ ext {
   versionCode = Integer.parseInt(VERSION_CODE)
   versionName = getVersionName()
 
-  minSdkVersion = 21
+  minSdkVersion = 23
   minSdkVersionWear = 25
   targetSdkVersion = 35
   compileSdkVersion = 35


### PR DESCRIPTION
## Actions performed:

### Bumped versions from analytics:
- Bumped Min SDK version from 21 to 23
- Bumped mockito core to 5.1.0: ByteBuddy requires Java 24, and is a dependency on mockito 5.21.0
- Bumped Okio to 3.16.4
- Bumped mockwebserver to 2.7.5
- Bumped assertj-core to 3.26.3 in order to comply with kotlin 2.0.21
- Bumped androidx.lifecycle:lifecycle-process and androidx.lifecycle:lifecycle-common-java8 from 2.9.1 to 2.10.0

### Bumped Versions from analytics-sample:
- viewPump to 2.1.1
- butterknife to 10.2.3
- retrofit to 3.0.0
- moshi to 3.0.0
- testrunner and test rules to 1.7.0

### Other actions performed:
- Adjusted Unit tests in order to comply with version bumps in mockito.

### Notes:
- Bumped Assertj to 3.24.2, largest available without breaking compatibility with bytebuddy.
- Cannot bump to Kotlin 2.3.0 since it breaks several dependencies. Will attempt to bump as much as possible without breaking functionalities.