### PR TITLE
feat(FRP-45): deep-link attribution — ad click IDs, UTM params, and i…

### DIFF
--- a/analytics/src/main/java/io/freshpaint/android/AnalyticsActivityLifecycleCallbacks.java
+++ b/analytics/src/main/java/io/freshpaint/android/AnalyticsActivityLifecycleCallbacks.java
@@ -32,6 +32,8 @@ import android.os.Bundle;
 import androidx.annotation.NonNull;
 import androidx.lifecycle.DefaultLifecycleObserver;
 import androidx.lifecycle.LifecycleOwner;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -137,14 +139,33 @@ class AnalyticsActivityLifecycleCallbacks
 
     Properties properties = new Properties();
     Uri uri = intent.getData();
+    Map<String, String> queryParams = new LinkedHashMap<>();
     for (String parameter : uri.getQueryParameterNames()) {
       String value = uri.getQueryParameter(parameter);
       if (value != null && !value.trim().isEmpty()) {
         properties.put(parameter, value);
+        queryParams.put(parameter, value);
       }
     }
 
     properties.put("url", uri.toString());
+
+    // Store deep-link attribution data (FRP-45). commit() is used so the data is visible to the
+    // analyticsExecutor background thread that may run trackApplicationLifecycleEvents() and
+    // read the same SharedPreferences immediately after this method returns.
+    long now = System.currentTimeMillis();
+    freshpaint.storeDeepLinkAttribution(queryParams, now);
+
+    // If app_install has already been tracked, enrich Deep Link Opened with the stored
+    // attribution fields ($gclid, utm_source, etc.). When app_install has not yet fired, the
+    // attribution is already stored and will be merged by trackApplicationLifecycleEvents().
+    if (freshpaint.isFirstOpenTracked()) {
+      Map<String, Object> attributionProps = freshpaint.getDeepLinkAttributionProperties(now);
+      for (Map.Entry<String, Object> entry : attributionProps.entrySet()) {
+        properties.put(entry.getKey(), entry.getValue());
+      }
+    }
+
     freshpaint.track("Deep Link Opened", properties);
   }
 

--- a/analytics/src/main/java/io/freshpaint/android/AnalyticsActivityLifecycleCallbacks.java
+++ b/analytics/src/main/java/io/freshpaint/android/AnalyticsActivityLifecycleCallbacks.java
@@ -160,10 +160,7 @@ class AnalyticsActivityLifecycleCallbacks
     // attribution fields ($gclid, utm_source, etc.). When app_install has not yet fired, the
     // attribution is already stored and will be merged by trackApplicationLifecycleEvents().
     if (freshpaint.isFirstOpenTracked()) {
-      Map<String, Object> attributionProps = freshpaint.getDeepLinkAttributionProperties(now);
-      for (Map.Entry<String, Object> entry : attributionProps.entrySet()) {
-        properties.put(entry.getKey(), entry.getValue());
-      }
+      properties.putAll(freshpaint.getDeepLinkAttributionProperties(now));
     }
 
     freshpaint.track("Deep Link Opened", properties);

--- a/analytics/src/main/java/io/freshpaint/android/AnalyticsActivityLifecycleCallbacks.java
+++ b/analytics/src/main/java/io/freshpaint/android/AnalyticsActivityLifecycleCallbacks.java
@@ -150,9 +150,10 @@ class AnalyticsActivityLifecycleCallbacks
 
     properties.put("url", uri.toString());
 
-    // Store deep-link attribution data (FRP-45). commit() is used so the data is visible to the
-    // analyticsExecutor background thread that may run trackApplicationLifecycleEvents() and
-    // read the same SharedPreferences immediately after this method returns.
+    // Store deep-link attribution data (FRP-45). commit() runs synchronously on the main thread;
+    // the trade-off is a small disk-write latency here in exchange for a guaranteed-visible read
+    // on the analyticsExecutor thread. apply() cannot substitute: the executor may be scheduled
+    // before apply()'s async flush completes, leaving getStoredProperties() reading stale data.
     long now = System.currentTimeMillis();
     freshpaint.storeDeepLinkAttribution(queryParams, now);
 

--- a/analytics/src/main/java/io/freshpaint/android/DeepLinkAttributionManager.java
+++ b/analytics/src/main/java/io/freshpaint/android/DeepLinkAttributionManager.java
@@ -39,6 +39,11 @@ import java.util.Map;
  * read time using a caller-supplied {@code now} timestamp to keep the class testable without mocks.
  *
  * <p>All public methods are static and never throw. Instances are not created.
+ *
+ * <p><b>Naming convention:</b> all ad-platform click IDs are stored and returned with a {@code $}
+ * prefix (e.g. {@code $gclid}, {@code $fbclid}). The Freshpaint-native click ID ({@code
+ * fp_click_id}) is stored and returned <em>without</em> the {@code $} prefix, matching the Install
+ * Referrer convention established in FRP-44.
  */
 final class DeepLinkAttributionManager {
 
@@ -90,65 +95,34 @@ final class DeepLinkAttributionManager {
     for (String id : AttributionConstants.CLICK_IDS) {
       String val = queryParams.get(id);
       if (val != null && !val.isEmpty()) {
-        String prefKey = DL_PREFIX + "$" + id;
-        String creationTimeKey = DL_PREFIX + "$" + id + "_creation_time";
-        String existing = prefs.getString(prefKey, null);
-        editor.putString(prefKey, val);
-        // Dedup: only update creation_time when the value changes.
-        if (!val.equals(existing)) {
-          editor.putLong(creationTimeKey, now);
-        }
+        putWithDedup(prefs, editor, DL_PREFIX + "$" + id, val, now);
       }
     }
 
     // Freshpaint click ID (stored without $ prefix, matching Install Referrer convention)
     String fpClickId = queryParams.get("fp_click_id");
     if (fpClickId != null && !fpClickId.isEmpty()) {
-      String existing = prefs.getString(KEY_FP_CLICK_ID, null);
-      editor.putString(KEY_FP_CLICK_ID, fpClickId);
-      if (!fpClickId.equals(existing)) {
-        editor.putLong(KEY_FP_CLICK_ID + "_creation_time", now);
-      }
+      putWithDedup(prefs, editor, KEY_FP_CLICK_ID, fpClickId, now);
     }
 
     // Google special: gacid → $gclid_campaign_id
     String gacid = queryParams.get("gacid");
     if (gacid != null && !gacid.isEmpty()) {
-      String key = DL_PREFIX + "$gclid_campaign_id";
-      String existing = prefs.getString(key, null);
-      editor.putString(key, gacid);
-      if (!gacid.equals(existing)) {
-        editor.putLong(key + "_creation_time", now);
-      }
+      putWithDedup(prefs, editor, DL_PREFIX + "$gclid_campaign_id", gacid, now);
     }
 
     // Facebook special fields
     String adId = queryParams.get("ad_id");
     if (adId != null && !adId.isEmpty()) {
-      String key = DL_PREFIX + "$fbclid_ad_id";
-      String existing = prefs.getString(key, null);
-      editor.putString(key, adId);
-      if (!adId.equals(existing)) {
-        editor.putLong(key + "_creation_time", now);
-      }
+      putWithDedup(prefs, editor, DL_PREFIX + "$fbclid_ad_id", adId, now);
     }
     String adsetId = queryParams.get("adset_id");
     if (adsetId != null && !adsetId.isEmpty()) {
-      String key = DL_PREFIX + "$fbclid_adset_id";
-      String existing = prefs.getString(key, null);
-      editor.putString(key, adsetId);
-      if (!adsetId.equals(existing)) {
-        editor.putLong(key + "_creation_time", now);
-      }
+      putWithDedup(prefs, editor, DL_PREFIX + "$fbclid_adset_id", adsetId, now);
     }
     String campaignId = queryParams.get("campaign_id");
     if (campaignId != null && !campaignId.isEmpty()) {
-      String key = DL_PREFIX + "$fbclid_campaign_id";
-      String existing = prefs.getString(key, null);
-      editor.putString(key, campaignId);
-      if (!campaignId.equals(existing)) {
-        editor.putLong(key + "_creation_time", now);
-      }
+      putWithDedup(prefs, editor, DL_PREFIX + "$fbclid_campaign_id", campaignId, now);
     }
 
     // UTM params — atomically replaced per deep link. When any UTM param is present, ALL five
@@ -157,7 +131,8 @@ final class DeepLinkAttributionManager {
     // with only utm_source must not re-surface a utm_campaign stored from a different campaign).
     boolean anyUtm = false;
     for (String utmKey : UTM_PARAMS) {
-      if (queryParams.get(utmKey) != null && !queryParams.get(utmKey).isEmpty()) {
+      String val = queryParams.get(utmKey);
+      if (val != null && !val.isEmpty()) {
         anyUtm = true;
         break;
       }
@@ -192,61 +167,19 @@ final class DeepLinkAttributionManager {
 
     // 24 ad-platform click IDs (no expiry)
     for (String id : AttributionConstants.CLICK_IDS) {
-      String val = prefs.getString(DL_PREFIX + "$" + id, null);
-      if (val != null) {
-        result.put("$" + id, val);
-        long creationTime = prefs.getLong(DL_PREFIX + "$" + id + "_creation_time", 0L);
-        if (creationTime != 0L) {
-          result.put("$" + id + "_creation_time", creationTime);
-        }
-      }
+      addWithCreationTime(prefs, result, DL_PREFIX + "$" + id, "$" + id);
     }
 
     // Freshpaint click ID
-    String fpClickId = prefs.getString(KEY_FP_CLICK_ID, null);
-    if (fpClickId != null) {
-      result.put("fp_click_id", fpClickId);
-      long ct = prefs.getLong(KEY_FP_CLICK_ID + "_creation_time", 0L);
-      if (ct != 0L) {
-        result.put("fp_click_id_creation_time", ct);
-      }
-    }
+    addWithCreationTime(prefs, result, KEY_FP_CLICK_ID, "fp_click_id");
 
     // Google special field
-    String gclidCampaignId = prefs.getString(DL_PREFIX + "$gclid_campaign_id", null);
-    if (gclidCampaignId != null) {
-      result.put("$gclid_campaign_id", gclidCampaignId);
-      long ct = prefs.getLong(DL_PREFIX + "$gclid_campaign_id_creation_time", 0L);
-      if (ct != 0L) {
-        result.put("$gclid_campaign_id_creation_time", ct);
-      }
-    }
+    addWithCreationTime(prefs, result, DL_PREFIX + "$gclid_campaign_id", "$gclid_campaign_id");
 
     // Facebook special fields
-    String fbclidAdId = prefs.getString(DL_PREFIX + "$fbclid_ad_id", null);
-    if (fbclidAdId != null) {
-      result.put("$fbclid_ad_id", fbclidAdId);
-      long ct = prefs.getLong(DL_PREFIX + "$fbclid_ad_id_creation_time", 0L);
-      if (ct != 0L) {
-        result.put("$fbclid_ad_id_creation_time", ct);
-      }
-    }
-    String fbclidAdsetId = prefs.getString(DL_PREFIX + "$fbclid_adset_id", null);
-    if (fbclidAdsetId != null) {
-      result.put("$fbclid_adset_id", fbclidAdsetId);
-      long ct = prefs.getLong(DL_PREFIX + "$fbclid_adset_id_creation_time", 0L);
-      if (ct != 0L) {
-        result.put("$fbclid_adset_id_creation_time", ct);
-      }
-    }
-    String fbclidCampaignId = prefs.getString(DL_PREFIX + "$fbclid_campaign_id", null);
-    if (fbclidCampaignId != null) {
-      result.put("$fbclid_campaign_id", fbclidCampaignId);
-      long ct = prefs.getLong(DL_PREFIX + "$fbclid_campaign_id_creation_time", 0L);
-      if (ct != 0L) {
-        result.put("$fbclid_campaign_id_creation_time", ct);
-      }
-    }
+    addWithCreationTime(prefs, result, DL_PREFIX + "$fbclid_ad_id", "$fbclid_ad_id");
+    addWithCreationTime(prefs, result, DL_PREFIX + "$fbclid_adset_id", "$fbclid_adset_id");
+    addWithCreationTime(prefs, result, DL_PREFIX + "$fbclid_campaign_id", "$fbclid_campaign_id");
 
     // UTM params — only include if stored within the last 24 hours
     long utmStoredAt = prefs.getLong(KEY_UTM_STORED_AT, 0L);
@@ -260,5 +193,43 @@ final class DeepLinkAttributionManager {
     }
 
     return result;
+  }
+
+  // -------------------------------------------------------------------------
+  // Private helpers
+  // -------------------------------------------------------------------------
+
+  /**
+   * Stores {@code value} under {@code prefKey} and updates {@code prefKey + "_creation_time"} to
+   * {@code now} only when the value has changed (deduplication).
+   */
+  private static void putWithDedup(
+      SharedPreferences prefs,
+      SharedPreferences.Editor editor,
+      String prefKey,
+      String value,
+      long now) {
+    String existing = prefs.getString(prefKey, null);
+    editor.putString(prefKey, value);
+    if (!value.equals(existing)) {
+      editor.putLong(prefKey + "_creation_time", now);
+    }
+  }
+
+  /**
+   * Reads {@code prefKey} from {@code prefs} and, if non-null, adds the value under {@code
+   * outputKey} and its creation timestamp under {@code outputKey + "_creation_time"} to {@code
+   * result}.
+   */
+  private static void addWithCreationTime(
+      SharedPreferences prefs, Map<String, Object> result, String prefKey, String outputKey) {
+    String val = prefs.getString(prefKey, null);
+    if (val != null) {
+      result.put(outputKey, val);
+      long ct = prefs.getLong(prefKey + "_creation_time", 0L);
+      if (ct != 0L) {
+        result.put(outputKey + "_creation_time", ct);
+      }
+    }
   }
 }

--- a/analytics/src/main/java/io/freshpaint/android/DeepLinkAttributionManager.java
+++ b/analytics/src/main/java/io/freshpaint/android/DeepLinkAttributionManager.java
@@ -1,0 +1,254 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014 Segment.io, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.freshpaint.android;
+
+import android.content.SharedPreferences;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Extracts and persists deep-link attribution data — 24 ad-platform click IDs, UTM parameters, and
+ * the Freshpaint click ID — from Intent URI query parameters captured by {@link
+ * AnalyticsActivityLifecycleCallbacks#trackDeepLink}.
+ *
+ * <p>All SharedPreferences keys use the {@code "dl."} prefix to avoid collisions with the Install
+ * Referrer namespace ({@code "ir."} from FRP-44).
+ *
+ * <p>Click IDs persist indefinitely. UTM parameters expire after 24 hours; expiry is evaluated at
+ * read time using a caller-supplied {@code now} timestamp to keep the class testable without mocks.
+ *
+ * <p>All public methods are static and never throw. Instances are not created.
+ */
+final class DeepLinkAttributionManager {
+
+  // -------------------------------------------------------------------------
+  // SharedPreferences key constants — all under "dl." prefix
+  // -------------------------------------------------------------------------
+
+  private static final String DL_PREFIX = "dl.";
+  private static final String KEY_FP_CLICK_ID = "dl.fp_click_id";
+
+  /** Timestamp written alongside UTM params; used to evaluate the 24-hour expiry window. */
+  private static final String KEY_UTM_STORED_AT = "dl.utm_stored_at";
+
+  private static final long UTM_EXPIRY_MS = 24L * 60L * 60L * 1_000L; // 24 hours in ms
+
+  private static final String[] UTM_PARAMS = {
+    "utm_source", "utm_medium", "utm_campaign", "utm_term", "utm_content"
+  };
+
+  private DeepLinkAttributionManager() {}
+
+  // -------------------------------------------------------------------------
+  // Public API
+  // -------------------------------------------------------------------------
+
+  /**
+   * Parses {@code queryParams} and persists attribution data to {@code prefs}.
+   *
+   * <p>Uses {@link SharedPreferences.Editor#commit()} (synchronous) so the written values are
+   * visible to background threads — in particular the SDK's {@code analyticsExecutor} — that may
+   * read {@code prefs} immediately after this method returns on the main thread.
+   *
+   * <p>Deduplication: if a click ID is already stored with the same value, its {@code
+   * _creation_time} is preserved. A changed value resets the creation time to {@code now}.
+   *
+   * @param queryParams key-value pairs extracted from the Intent URI (empty values already filtered
+   *     out by the caller); {@code null} or empty map is a no-op
+   * @param prefs the SDK's SharedPreferences instance
+   * @param now current time in Unix milliseconds (caller-supplied for testability)
+   */
+  static void store(Map<String, String> queryParams, SharedPreferences prefs, long now) {
+    if (queryParams == null || queryParams.isEmpty()) {
+      return;
+    }
+
+    SharedPreferences.Editor editor = prefs.edit();
+
+    // 24 ad-platform click IDs
+    for (String id : AttributionConstants.CLICK_IDS) {
+      String val = queryParams.get(id);
+      if (val != null && !val.isEmpty()) {
+        String prefKey = DL_PREFIX + "$" + id;
+        String creationTimeKey = DL_PREFIX + "$" + id + "_creation_time";
+        String existing = prefs.getString(prefKey, null);
+        editor.putString(prefKey, val);
+        // Dedup: only update creation_time when the value changes.
+        if (!val.equals(existing)) {
+          editor.putLong(creationTimeKey, now);
+        }
+      }
+    }
+
+    // Freshpaint click ID (stored without $ prefix, matching Install Referrer convention)
+    String fpClickId = queryParams.get("fp_click_id");
+    if (fpClickId != null && !fpClickId.isEmpty()) {
+      String existing = prefs.getString(KEY_FP_CLICK_ID, null);
+      editor.putString(KEY_FP_CLICK_ID, fpClickId);
+      if (!fpClickId.equals(existing)) {
+        editor.putLong(KEY_FP_CLICK_ID + "_creation_time", now);
+      }
+    }
+
+    // Google special: gacid → $gclid_campaign_id
+    String gacid = queryParams.get("gacid");
+    if (gacid != null && !gacid.isEmpty()) {
+      String key = DL_PREFIX + "$gclid_campaign_id";
+      String existing = prefs.getString(key, null);
+      editor.putString(key, gacid);
+      if (!gacid.equals(existing)) {
+        editor.putLong(key + "_creation_time", now);
+      }
+    }
+
+    // Facebook special fields
+    String adId = queryParams.get("ad_id");
+    if (adId != null && !adId.isEmpty()) {
+      String key = DL_PREFIX + "$fbclid_ad_id";
+      String existing = prefs.getString(key, null);
+      editor.putString(key, adId);
+      if (!adId.equals(existing)) {
+        editor.putLong(key + "_creation_time", now);
+      }
+    }
+    String adsetId = queryParams.get("adset_id");
+    if (adsetId != null && !adsetId.isEmpty()) {
+      String key = DL_PREFIX + "$fbclid_adset_id";
+      String existing = prefs.getString(key, null);
+      editor.putString(key, adsetId);
+      if (!adsetId.equals(existing)) {
+        editor.putLong(key + "_creation_time", now);
+      }
+    }
+    String campaignId = queryParams.get("campaign_id");
+    if (campaignId != null && !campaignId.isEmpty()) {
+      String key = DL_PREFIX + "$fbclid_campaign_id";
+      String existing = prefs.getString(key, null);
+      editor.putString(key, campaignId);
+      if (!campaignId.equals(existing)) {
+        editor.putLong(key + "_creation_time", now);
+      }
+    }
+
+    // UTM params — stored with a timestamp for expiry evaluation at read time
+    boolean anyUtm = false;
+    for (String utmKey : UTM_PARAMS) {
+      String val = queryParams.get(utmKey);
+      if (val != null && !val.isEmpty()) {
+        editor.putString(DL_PREFIX + "utm." + utmKey, val);
+        anyUtm = true;
+      }
+    }
+    if (anyUtm) {
+      editor.putLong(KEY_UTM_STORED_AT, now);
+    }
+
+    editor.commit();
+  }
+
+  /**
+   * Returns all stored deep-link attribution properties ready to be merged into an event payload.
+   *
+   * <p>Click IDs are always included if present. UTM parameters are omitted when they were stored
+   * more than 24 hours before {@code now}.
+   *
+   * @param prefs the SDK's SharedPreferences instance
+   * @param now current time in Unix milliseconds (caller-supplied for testability)
+   * @return attribution key-value pairs; empty map if nothing has been stored
+   */
+  static Map<String, Object> getStoredProperties(SharedPreferences prefs, long now) {
+    Map<String, Object> result = new LinkedHashMap<>();
+
+    // 24 ad-platform click IDs (no expiry)
+    for (String id : AttributionConstants.CLICK_IDS) {
+      String val = prefs.getString(DL_PREFIX + "$" + id, null);
+      if (val != null) {
+        result.put("$" + id, val);
+        long creationTime = prefs.getLong(DL_PREFIX + "$" + id + "_creation_time", 0L);
+        if (creationTime != 0L) {
+          result.put("$" + id + "_creation_time", creationTime);
+        }
+      }
+    }
+
+    // Freshpaint click ID
+    String fpClickId = prefs.getString(KEY_FP_CLICK_ID, null);
+    if (fpClickId != null) {
+      result.put("fp_click_id", fpClickId);
+      long ct = prefs.getLong(KEY_FP_CLICK_ID + "_creation_time", 0L);
+      if (ct != 0L) {
+        result.put("fp_click_id_creation_time", ct);
+      }
+    }
+
+    // Google special field
+    String gclidCampaignId = prefs.getString(DL_PREFIX + "$gclid_campaign_id", null);
+    if (gclidCampaignId != null) {
+      result.put("$gclid_campaign_id", gclidCampaignId);
+      long ct = prefs.getLong(DL_PREFIX + "$gclid_campaign_id_creation_time", 0L);
+      if (ct != 0L) {
+        result.put("$gclid_campaign_id_creation_time", ct);
+      }
+    }
+
+    // Facebook special fields
+    String fbclidAdId = prefs.getString(DL_PREFIX + "$fbclid_ad_id", null);
+    if (fbclidAdId != null) {
+      result.put("$fbclid_ad_id", fbclidAdId);
+      long ct = prefs.getLong(DL_PREFIX + "$fbclid_ad_id_creation_time", 0L);
+      if (ct != 0L) {
+        result.put("$fbclid_ad_id_creation_time", ct);
+      }
+    }
+    String fbclidAdsetId = prefs.getString(DL_PREFIX + "$fbclid_adset_id", null);
+    if (fbclidAdsetId != null) {
+      result.put("$fbclid_adset_id", fbclidAdsetId);
+      long ct = prefs.getLong(DL_PREFIX + "$fbclid_adset_id_creation_time", 0L);
+      if (ct != 0L) {
+        result.put("$fbclid_adset_id_creation_time", ct);
+      }
+    }
+    String fbclidCampaignId = prefs.getString(DL_PREFIX + "$fbclid_campaign_id", null);
+    if (fbclidCampaignId != null) {
+      result.put("$fbclid_campaign_id", fbclidCampaignId);
+      long ct = prefs.getLong(DL_PREFIX + "$fbclid_campaign_id_creation_time", 0L);
+      if (ct != 0L) {
+        result.put("$fbclid_campaign_id_creation_time", ct);
+      }
+    }
+
+    // UTM params — only include if stored within the last 24 hours
+    long utmStoredAt = prefs.getLong(KEY_UTM_STORED_AT, 0L);
+    if (utmStoredAt > 0L && (now - utmStoredAt) <= UTM_EXPIRY_MS) {
+      for (String utmKey : UTM_PARAMS) {
+        String val = prefs.getString(DL_PREFIX + "utm." + utmKey, null);
+        if (val != null) {
+          result.put(utmKey, val);
+        }
+      }
+    }
+
+    return result;
+  }
+}

--- a/analytics/src/main/java/io/freshpaint/android/DeepLinkAttributionManager.java
+++ b/analytics/src/main/java/io/freshpaint/android/DeepLinkAttributionManager.java
@@ -151,16 +151,26 @@ final class DeepLinkAttributionManager {
       }
     }
 
-    // UTM params — stored with a timestamp for expiry evaluation at read time
+    // UTM params — atomically replaced per deep link. When any UTM param is present, ALL five
+    // UTM keys are evaluated: present keys are written, absent keys are explicitly removed. This
+    // prevents stale values from a previous deep link mixing with partial updates (e.g. a URL
+    // with only utm_source must not re-surface a utm_campaign stored from a different campaign).
     boolean anyUtm = false;
     for (String utmKey : UTM_PARAMS) {
-      String val = queryParams.get(utmKey);
-      if (val != null && !val.isEmpty()) {
-        editor.putString(DL_PREFIX + "utm." + utmKey, val);
+      if (queryParams.get(utmKey) != null && !queryParams.get(utmKey).isEmpty()) {
         anyUtm = true;
+        break;
       }
     }
     if (anyUtm) {
+      for (String utmKey : UTM_PARAMS) {
+        String val = queryParams.get(utmKey);
+        if (val != null && !val.isEmpty()) {
+          editor.putString(DL_PREFIX + "utm." + utmKey, val);
+        } else {
+          editor.remove(DL_PREFIX + "utm." + utmKey);
+        }
+      }
       editor.putLong(KEY_UTM_STORED_AT, now);
     }
 

--- a/analytics/src/main/java/io/freshpaint/android/Freshpaint.java
+++ b/analytics/src/main/java/io/freshpaint/android/Freshpaint.java
@@ -408,12 +408,9 @@ public class Freshpaint {
         // trackDeepLink() will have persisted click IDs and UTM params via commit() on the main
         // thread before this executor task runs. Deep-link values overwrite IR values for
         // overlapping keys (e.g. $gclid) since the deep link represents a more direct signal.
-        Map<String, Object> dlData =
+        installProps.putAll(
             DeepLinkAttributionManager.getStoredProperties(
-                sharedPreferences, System.currentTimeMillis());
-        for (Map.Entry<String, Object> entry : dlData.entrySet()) {
-          installProps.putValue(entry.getKey(), entry.getValue());
-        }
+                sharedPreferences, System.currentTimeMillis()));
         track("app_install", installProps);
       }
     } else if (currentBuild != previousBuild) {
@@ -434,6 +431,10 @@ public class Freshpaint {
     // users who skip previousBuild==-1 are also guarded against future re-fires. This key means
     // "app_install will not fire again", not "app_install was fired on this device".
     editor.putBoolean(FIRST_OPEN_TRACKED_KEY, true);
+    // apply() updates the in-memory SharedPreferences cache synchronously before returning, so
+    // isFirstOpenTracked() reads the new value immediately on the same thread. The async disk
+    // write is sufficient here — unlike store() in DeepLinkAttributionManager, this write does
+    // not need to be visible to a background thread before the next line.
     editor.apply();
   }
 

--- a/analytics/src/main/java/io/freshpaint/android/Freshpaint.java
+++ b/analytics/src/main/java/io/freshpaint/android/Freshpaint.java
@@ -294,6 +294,42 @@ public class Freshpaint {
     lifecycle.addObserver(activityLifecycleCallback);
   }
 
+  // -------------------------------------------------------------------------
+  // Deep-link attribution (FRP-45)
+  // -------------------------------------------------------------------------
+
+  /**
+   * Persists deep-link attribution data (click IDs and UTM params) extracted from the Intent URI to
+   * SharedPreferences. Called from {@link AnalyticsActivityLifecycleCallbacks#trackDeepLink} on the
+   * main thread; uses {@code commit()} so data is visible to the {@code analyticsExecutor}
+   * background thread immediately.
+   */
+  @Private
+  void storeDeepLinkAttribution(Map<String, String> queryParams, long now) {
+    SharedPreferences prefs = Utils.getFreshpaintSharedPreferences(application, tag);
+    DeepLinkAttributionManager.store(queryParams, prefs, now);
+  }
+
+  /**
+   * Returns {@code true} if the {@code app_install} first-open event has already been tracked (i.e.
+   * {@code FIRST_OPEN_TRACKED_KEY} is set in SharedPreferences).
+   */
+  @Private
+  boolean isFirstOpenTracked() {
+    SharedPreferences prefs = Utils.getFreshpaintSharedPreferences(application, tag);
+    return prefs.getBoolean(FIRST_OPEN_TRACKED_KEY, false);
+  }
+
+  /**
+   * Returns stored deep-link attribution properties ready to be merged into an event payload. UTM
+   * params are omitted when they have expired (older than 24 hours from {@code now}).
+   */
+  @Private
+  Map<String, Object> getDeepLinkAttributionProperties(long now) {
+    SharedPreferences prefs = Utils.getFreshpaintSharedPreferences(application, tag);
+    return DeepLinkAttributionManager.getStoredProperties(prefs, now);
+  }
+
   @Private
   void trackAttributionInformation() {
     // Both this method and trackApplicationLifecycleEvents() call
@@ -366,6 +402,16 @@ public class Freshpaint {
         // map is empty and no fields are added.
         Map<String, Object> irData = InstallReferrerManager.getStoredProperties(sharedPreferences);
         for (Map.Entry<String, Object> entry : irData.entrySet()) {
+          installProps.putValue(entry.getKey(), entry.getValue());
+        }
+        // Merge deep-link attribution data (FRP-45). If a deep link fired before app_install,
+        // trackDeepLink() will have persisted click IDs and UTM params via commit() on the main
+        // thread before this executor task runs. Deep-link values overwrite IR values for
+        // overlapping keys (e.g. $gclid) since the deep link represents a more direct signal.
+        Map<String, Object> dlData =
+            DeepLinkAttributionManager.getStoredProperties(
+                sharedPreferences, System.currentTimeMillis());
+        for (Map.Entry<String, Object> entry : dlData.entrySet()) {
           installProps.putValue(entry.getKey(), entry.getValue());
         }
         track("app_install", installProps);

--- a/analytics/src/test/java/io/freshpaint/android/DeepLinkAttributionManagerTest.java
+++ b/analytics/src/test/java/io/freshpaint/android/DeepLinkAttributionManagerTest.java
@@ -268,6 +268,56 @@ public class DeepLinkAttributionManagerTest {
   }
 
   // -------------------------------------------------------------------------
+  // UTM atomic replacement — partial update must not mix with stale values
+  // -------------------------------------------------------------------------
+
+  /**
+   * When a second deep link carries only a subset of UTM params, the UTM keys absent from the new
+   * URL must be cleared. This prevents cross-campaign contamination (e.g. utm_source=facebook mixed
+   * with utm_campaign=summer_sale from a previous Google campaign).
+   */
+  @Test
+  public void store_partialUtmUpdate_clearsPreviousUtmKeys() {
+    // First deep link: utm_source + utm_campaign
+    Map<String, String> params1 = new LinkedHashMap<>();
+    params1.put("utm_source", "google");
+    params1.put("utm_campaign", "summer_sale");
+    DeepLinkAttributionManager.store(params1, prefs, T0);
+
+    // Second deep link: only utm_source — utm_campaign must NOT survive
+    Map<String, String> params2 = new LinkedHashMap<>();
+    params2.put("utm_source", "facebook");
+    DeepLinkAttributionManager.store(params2, prefs, T1);
+
+    Map<String, Object> stored = DeepLinkAttributionManager.getStoredProperties(prefs, T1);
+    assertThat(stored).containsEntry("utm_source", "facebook");
+    assertThat(stored).doesNotContainKey("utm_campaign");
+    assertThat(stored).doesNotContainKey("utm_medium");
+    assertThat(stored).doesNotContainKey("utm_term");
+    assertThat(stored).doesNotContainKey("utm_content");
+  }
+
+  /**
+   * utm_stored_at must be updated to the new timestamp on partial updates so the expiry window is
+   * anchored to the most recent deep link, not the original one.
+   */
+  @Test
+  public void store_partialUtmUpdate_refreshesStoredAtTimestamp() {
+    Map<String, String> params1 = new LinkedHashMap<>();
+    params1.put("utm_source", "google");
+    DeepLinkAttributionManager.store(params1, prefs, T0);
+
+    Map<String, String> params2 = new LinkedHashMap<>();
+    params2.put("utm_medium", "cpc");
+    DeepLinkAttributionManager.store(params2, prefs, T1);
+
+    // utm_stored_at is now T1; both reads at T1 must return the new UTM set only
+    Map<String, Object> stored = DeepLinkAttributionManager.getStoredProperties(prefs, T1);
+    assertThat(stored).containsEntry("utm_medium", "cpc");
+    assertThat(stored).doesNotContainKey("utm_source");
+  }
+
+  // -------------------------------------------------------------------------
   // fp_click_id stored without $ prefix
   // -------------------------------------------------------------------------
 

--- a/analytics/src/test/java/io/freshpaint/android/DeepLinkAttributionManagerTest.java
+++ b/analytics/src/test/java/io/freshpaint/android/DeepLinkAttributionManagerTest.java
@@ -1,0 +1,378 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014 Segment.io, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.freshpaint.android;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link DeepLinkAttributionManager}. All tests use {@link FakeSharedPreferences}
+ * and a controlled {@code now} timestamp — no Android framework or Robolectric required.
+ */
+public class DeepLinkAttributionManagerTest {
+
+  private static final long T0 = 1_000_000L;
+  private static final long T1 = T0 + 1_000L;
+  private static final long T_25H = T0 + 25L * 60L * 60L * 1_000L;
+
+  private FakeSharedPreferences prefs;
+
+  @Before
+  public void setUp() {
+    prefs = new FakeSharedPreferences();
+  }
+
+  // -------------------------------------------------------------------------
+  // AC1 + AC2: all 24 click IDs extracted with $ prefix
+  // -------------------------------------------------------------------------
+
+  @Test
+  public void store_allTwentyFourClickIds_storedWithDollarPrefix() {
+    Map<String, String> params = new LinkedHashMap<>();
+    for (String id : AttributionConstants.CLICK_IDS) {
+      params.put(id, "val_" + id);
+    }
+
+    DeepLinkAttributionManager.store(params, prefs, T0);
+
+    Map<String, Object> stored = DeepLinkAttributionManager.getStoredProperties(prefs, T0);
+    for (String id : AttributionConstants.CLICK_IDS) {
+      assertThat(stored).containsEntry("$" + id, "val_" + id);
+      // AC3: each has a creation_time
+      assertThat(stored).containsKey("$" + id + "_creation_time");
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // AC3: creation_time set to now on first store
+  // -------------------------------------------------------------------------
+
+  @Test
+  public void store_clickId_setsCreationTimeToNow() {
+    Map<String, String> params = new LinkedHashMap<>();
+    params.put("gclid", "GCL123");
+
+    DeepLinkAttributionManager.store(params, prefs, T0);
+
+    Map<String, Object> stored = DeepLinkAttributionManager.getStoredProperties(prefs, T0);
+    assertThat(stored).containsEntry("$gclid", "GCL123");
+    assertThat(stored).containsEntry("$gclid_creation_time", T0);
+  }
+
+  // -------------------------------------------------------------------------
+  // AC4: gacid → $gclid_campaign_id
+  // -------------------------------------------------------------------------
+
+  @Test
+  public void store_gacid_storedAsGclidCampaignId() {
+    Map<String, String> params = new LinkedHashMap<>();
+    params.put("gacid", "CAMPAIGN_ABC");
+
+    DeepLinkAttributionManager.store(params, prefs, T0);
+
+    Map<String, Object> stored = DeepLinkAttributionManager.getStoredProperties(prefs, T0);
+    assertThat(stored).containsEntry("$gclid_campaign_id", "CAMPAIGN_ABC");
+    assertThat(stored).containsEntry("$gclid_campaign_id_creation_time", T0);
+  }
+
+  @Test
+  public void store_gacid_sameValue_doesNotUpdateCreationTime() {
+    Map<String, String> params = new LinkedHashMap<>();
+    params.put("gacid", "SAME_CAMPAIGN");
+    DeepLinkAttributionManager.store(params, prefs, T0);
+    DeepLinkAttributionManager.store(params, prefs, T1);
+
+    Map<String, Object> stored = DeepLinkAttributionManager.getStoredProperties(prefs, T1);
+    assertThat(stored).containsEntry("$gclid_campaign_id", "SAME_CAMPAIGN");
+    assertThat(stored).containsEntry("$gclid_campaign_id_creation_time", T0);
+  }
+
+  @Test
+  public void store_gacid_differentValue_updatesCreationTime() {
+    Map<String, String> params1 = new LinkedHashMap<>();
+    params1.put("gacid", "OLD_CAMPAIGN");
+    DeepLinkAttributionManager.store(params1, prefs, T0);
+
+    Map<String, String> params2 = new LinkedHashMap<>();
+    params2.put("gacid", "NEW_CAMPAIGN");
+    DeepLinkAttributionManager.store(params2, prefs, T1);
+
+    Map<String, Object> stored = DeepLinkAttributionManager.getStoredProperties(prefs, T1);
+    assertThat(stored).containsEntry("$gclid_campaign_id", "NEW_CAMPAIGN");
+    assertThat(stored).containsEntry("$gclid_campaign_id_creation_time", T1);
+  }
+
+  // -------------------------------------------------------------------------
+  // AC5: Facebook special fields
+  // -------------------------------------------------------------------------
+
+  @Test
+  public void store_facebookSpecialFields_mappedCorrectly() {
+    Map<String, String> params = new LinkedHashMap<>();
+    params.put("fbclid", "FB_CLICK_ID");
+    params.put("ad_id", "AD_123");
+    params.put("adset_id", "ADSET_456");
+    params.put("campaign_id", "CAMP_789");
+
+    DeepLinkAttributionManager.store(params, prefs, T0);
+
+    Map<String, Object> stored = DeepLinkAttributionManager.getStoredProperties(prefs, T0);
+    assertThat(stored).containsEntry("$fbclid", "FB_CLICK_ID");
+    assertThat(stored).containsEntry("$fbclid_ad_id", "AD_123");
+    assertThat(stored).containsEntry("$fbclid_adset_id", "ADSET_456");
+    assertThat(stored).containsEntry("$fbclid_campaign_id", "CAMP_789");
+    assertThat(stored).containsEntry("$fbclid_ad_id_creation_time", T0);
+    assertThat(stored).containsEntry("$fbclid_adset_id_creation_time", T0);
+    assertThat(stored).containsEntry("$fbclid_campaign_id_creation_time", T0);
+  }
+
+  @Test
+  public void store_facebookSpecialFields_sameValues_doNotUpdateCreationTimes() {
+    Map<String, String> params = new LinkedHashMap<>();
+    params.put("ad_id", "AD_SAME");
+    params.put("adset_id", "ADSET_SAME");
+    params.put("campaign_id", "CAMP_SAME");
+    DeepLinkAttributionManager.store(params, prefs, T0);
+    DeepLinkAttributionManager.store(params, prefs, T1);
+
+    Map<String, Object> stored = DeepLinkAttributionManager.getStoredProperties(prefs, T1);
+    assertThat(stored).containsEntry("$fbclid_ad_id_creation_time", T0);
+    assertThat(stored).containsEntry("$fbclid_adset_id_creation_time", T0);
+    assertThat(stored).containsEntry("$fbclid_campaign_id_creation_time", T0);
+  }
+
+  // -------------------------------------------------------------------------
+  // AC6: deduplication — same value preserves creation_time
+  // -------------------------------------------------------------------------
+
+  @Test
+  public void store_sameClickIdValue_doesNotUpdateCreationTime() {
+    Map<String, String> params = new LinkedHashMap<>();
+    params.put("gclid", "SAME_VALUE");
+    DeepLinkAttributionManager.store(params, prefs, T0);
+
+    // Same value, later timestamp — creation_time must NOT change
+    DeepLinkAttributionManager.store(params, prefs, T1);
+
+    Map<String, Object> stored = DeepLinkAttributionManager.getStoredProperties(prefs, T1);
+    assertThat(stored).containsEntry("$gclid", "SAME_VALUE");
+    assertThat(stored).containsEntry("$gclid_creation_time", T0);
+  }
+
+  // AC6: deduplication — different value resets creation_time
+  @Test
+  public void store_differentClickIdValue_updatesCreationTime() {
+    Map<String, String> params1 = new LinkedHashMap<>();
+    params1.put("gclid", "OLD_VALUE");
+    DeepLinkAttributionManager.store(params1, prefs, T0);
+
+    Map<String, String> params2 = new LinkedHashMap<>();
+    params2.put("gclid", "NEW_VALUE");
+    DeepLinkAttributionManager.store(params2, prefs, T1);
+
+    Map<String, Object> stored = DeepLinkAttributionManager.getStoredProperties(prefs, T1);
+    assertThat(stored).containsEntry("$gclid", "NEW_VALUE");
+    assertThat(stored).containsEntry("$gclid_creation_time", T1);
+  }
+
+  // -------------------------------------------------------------------------
+  // AC7: click IDs persist after 24 hours (no expiry)
+  // -------------------------------------------------------------------------
+
+  @Test
+  public void getStoredProperties_clickIdPersistsAfter24h() {
+    Map<String, String> params = new LinkedHashMap<>();
+    params.put("gclid", "PERSIST_ME");
+    DeepLinkAttributionManager.store(params, prefs, T0);
+
+    Map<String, Object> stored = DeepLinkAttributionManager.getStoredProperties(prefs, T_25H);
+    assertThat(stored).containsEntry("$gclid", "PERSIST_ME");
+    assertThat(stored).containsEntry("$gclid_creation_time", T0);
+  }
+
+  // -------------------------------------------------------------------------
+  // AC8: UTM params stored
+  // -------------------------------------------------------------------------
+
+  @Test
+  public void store_utmParams_allFiveStored() {
+    Map<String, String> params = new LinkedHashMap<>();
+    params.put("utm_source", "facebook");
+    params.put("utm_medium", "cpc");
+    params.put("utm_campaign", "summer_sale");
+    params.put("utm_term", "shoes");
+    params.put("utm_content", "banner_v2");
+
+    DeepLinkAttributionManager.store(params, prefs, T0);
+
+    Map<String, Object> stored = DeepLinkAttributionManager.getStoredProperties(prefs, T0);
+    assertThat(stored).containsEntry("utm_source", "facebook");
+    assertThat(stored).containsEntry("utm_medium", "cpc");
+    assertThat(stored).containsEntry("utm_campaign", "summer_sale");
+    assertThat(stored).containsEntry("utm_term", "shoes");
+    assertThat(stored).containsEntry("utm_content", "banner_v2");
+  }
+
+  // -------------------------------------------------------------------------
+  // AC9: UTM expiry
+  // -------------------------------------------------------------------------
+
+  @Test
+  public void getStoredProperties_utmReturnedExactlyAt24hBoundary() {
+    Map<String, String> params = new LinkedHashMap<>();
+    params.put("utm_source", "google");
+    DeepLinkAttributionManager.store(params, prefs, T0);
+
+    // Exactly at 24 h — should still be returned (boundary is inclusive: <= UTM_EXPIRY_MS)
+    long exactly24h = T0 + 24L * 60L * 60L * 1_000L;
+    Map<String, Object> stored = DeepLinkAttributionManager.getStoredProperties(prefs, exactly24h);
+    assertThat(stored).containsEntry("utm_source", "google");
+  }
+
+  @Test
+  public void getStoredProperties_utmExpiredAfter24h() {
+    Map<String, String> params = new LinkedHashMap<>();
+    params.put("utm_source", "google");
+    params.put("gclid", "KEEP_ME"); // click ID must survive even when UTM expires
+    DeepLinkAttributionManager.store(params, prefs, T0);
+
+    long after24h = T0 + 24L * 60L * 60L * 1_000L + 1L;
+    Map<String, Object> stored = DeepLinkAttributionManager.getStoredProperties(prefs, after24h);
+    assertThat(stored).doesNotContainKey("utm_source");
+    assertThat(stored).containsEntry("$gclid", "KEEP_ME");
+  }
+
+  // -------------------------------------------------------------------------
+  // fp_click_id stored without $ prefix
+  // -------------------------------------------------------------------------
+
+  @Test
+  public void store_fpClickId_storedWithoutDollarPrefix() {
+    Map<String, String> params = new LinkedHashMap<>();
+    params.put("fp_click_id", "fp_abc123");
+
+    DeepLinkAttributionManager.store(params, prefs, T0);
+
+    Map<String, Object> stored = DeepLinkAttributionManager.getStoredProperties(prefs, T0);
+    assertThat(stored).containsEntry("fp_click_id", "fp_abc123");
+    assertThat(stored).containsEntry("fp_click_id_creation_time", T0);
+    assertThat(stored).doesNotContainKey("$fp_click_id");
+  }
+
+  @Test
+  public void store_fpClickId_sameValue_doesNotUpdateCreationTime() {
+    Map<String, String> params = new LinkedHashMap<>();
+    params.put("fp_click_id", "fp_SAME");
+    DeepLinkAttributionManager.store(params, prefs, T0);
+    DeepLinkAttributionManager.store(params, prefs, T1);
+
+    Map<String, Object> stored = DeepLinkAttributionManager.getStoredProperties(prefs, T1);
+    assertThat(stored).containsEntry("fp_click_id", "fp_SAME");
+    assertThat(stored).containsEntry("fp_click_id_creation_time", T0);
+  }
+
+  @Test
+  public void store_fpClickId_differentValue_updatesCreationTime() {
+    Map<String, String> params1 = new LinkedHashMap<>();
+    params1.put("fp_click_id", "fp_OLD");
+    DeepLinkAttributionManager.store(params1, prefs, T0);
+
+    Map<String, String> params2 = new LinkedHashMap<>();
+    params2.put("fp_click_id", "fp_NEW");
+    DeepLinkAttributionManager.store(params2, prefs, T1);
+
+    Map<String, Object> stored = DeepLinkAttributionManager.getStoredProperties(prefs, T1);
+    assertThat(stored).containsEntry("fp_click_id", "fp_NEW");
+    assertThat(stored).containsEntry("fp_click_id_creation_time", T1);
+  }
+
+  // -------------------------------------------------------------------------
+  // Edge cases: null / empty input
+  // -------------------------------------------------------------------------
+
+  @Test
+  public void store_emptyParams_noExceptionAndEmptyResult() {
+    DeepLinkAttributionManager.store(new LinkedHashMap<>(), prefs, T0);
+
+    assertThat(DeepLinkAttributionManager.getStoredProperties(prefs, T0)).isEmpty();
+  }
+
+  @Test
+  public void store_nullParams_noException() {
+    DeepLinkAttributionManager.store(null, prefs, T0);
+
+    assertThat(DeepLinkAttributionManager.getStoredProperties(prefs, T0)).isEmpty();
+  }
+
+  @Test
+  public void getStoredProperties_nothingStored_returnsEmptyMap() {
+    assertThat(DeepLinkAttributionManager.getStoredProperties(prefs, T0)).isEmpty();
+  }
+
+  // -------------------------------------------------------------------------
+  // Round-trip correctness
+  // -------------------------------------------------------------------------
+
+  @Test
+  public void store_thenGetStoredProperties_roundTrip() {
+    Map<String, String> params = new LinkedHashMap<>();
+    params.put("fbclid", "FB_ID");
+    params.put("fp_click_id", "fp_xyz");
+    params.put("utm_source", "tiktok");
+    params.put("gacid", "CAM_123");
+
+    DeepLinkAttributionManager.store(params, prefs, T0);
+    Map<String, Object> stored = DeepLinkAttributionManager.getStoredProperties(prefs, T0);
+
+    assertThat(stored).containsEntry("$fbclid", "FB_ID");
+    assertThat(stored).containsEntry("$fbclid_creation_time", T0);
+    assertThat(stored).containsEntry("fp_click_id", "fp_xyz");
+    assertThat(stored).containsEntry("fp_click_id_creation_time", T0);
+    assertThat(stored).containsEntry("utm_source", "tiktok");
+    assertThat(stored).containsEntry("$gclid_campaign_id", "CAM_123");
+    assertThat(stored).containsEntry("$gclid_campaign_id_creation_time", T0);
+  }
+
+  // -------------------------------------------------------------------------
+  // UTM not stored when no UTM params present
+  // -------------------------------------------------------------------------
+
+  @Test
+  public void store_noUtmParams_utmStoredAtNotSet() {
+    Map<String, String> params = new LinkedHashMap<>();
+    params.put("gclid", "GCL123");
+    // No UTM params
+
+    DeepLinkAttributionManager.store(params, prefs, T0);
+
+    // UTM params should not appear even within expiry window
+    Map<String, Object> stored = DeepLinkAttributionManager.getStoredProperties(prefs, T0);
+    assertThat(stored).doesNotContainKey("utm_source");
+    assertThat(stored).doesNotContainKey("utm_campaign");
+  }
+}

--- a/analytics/src/test/java/io/freshpaint/android/FreshpaintInstallEventTest.java
+++ b/analytics/src/test/java/io/freshpaint/android/FreshpaintInstallEventTest.java
@@ -39,7 +39,9 @@ import io.freshpaint.android.integrations.Logger;
 import io.freshpaint.android.integrations.TrackPayload;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.AbstractExecutorService;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -473,6 +475,98 @@ public class FreshpaintInstallEventTest {
     assertThat(props.get("utm_campaign")).isEqualTo("winter_sale");
     assertThat(props.get("$gclid")).isEqualTo("test-gclid-value");
     assertThat(props.get("$gclid_creation_time")).isEqualTo(1710000000000L);
+  }
+
+  // -------------------------------------------------------------------------
+  // AC10 (FRP-45) — Deep-link attribution merged into app_install
+  // -------------------------------------------------------------------------
+
+  /**
+   * When a deep link fires before app_install (first install scenario), the stored deep-link
+   * attribution data must appear in the {@code app_install} payload. This test pre-populates
+   * SharedPreferences with DL attribution (simulating a prior {@code trackDeepLink()} call) and
+   * asserts the fields are present in the emitted event.
+   */
+  @Test
+  public void appInstallIncludesStoredDeepLinkAttribution() {
+    // Simulate trackDeepLink() having already stored DL attribution before app_install fires.
+    Map<String, String> dlParams = new LinkedHashMap<>();
+    dlParams.put("gclid", "DL_GCLID_123");
+    dlParams.put("utm_source", "facebook");
+    // Use a fixed timestamp well within the 24-hour UTM expiry window.
+    DeepLinkAttributionManager.store(dlParams, fakePrefs, 1_000_000L);
+
+    Freshpaint fp = buildFreshpaint(true);
+    fp.trackApplicationLifecycleEvents();
+
+    assertThat(tracksOf(captured)).hasSize(1);
+    Properties props = tracksOf(captured).get(0).properties();
+    assertThat(props.get("$gclid")).isEqualTo("DL_GCLID_123");
+    assertThat(props).containsKey("$gclid_creation_time");
+    // UTM stored at T=1_000_000ms; getStoredProperties called at System.currentTimeMillis()
+    // (>> 1_000_000ms so the UTM window IS expired — see note below). Only asserting click ID.
+  }
+
+  /**
+   * DL click IDs must appear in {@code app_install} even when the IR prefs are also populated —
+   * confirming DL data overwrites IR data for overlapping keys.
+   */
+  @Test
+  public void appInstallDlOverwritesIrForOverlappingKeys() {
+    // IR has a gclid value
+    fakePrefs.store.put(InstallReferrerManager.KEY_IR_COLLECTED, true);
+    fakePrefs.store.put("ir.$gclid", "IR_GCLID_VALUE");
+    fakePrefs.store.put("ir.$gclid_creation_time", 500_000L);
+
+    // DL has a different gclid value (more recent / more direct signal)
+    Map<String, String> dlParams = new LinkedHashMap<>();
+    dlParams.put("gclid", "DL_GCLID_VALUE");
+    DeepLinkAttributionManager.store(dlParams, fakePrefs, 1_000_000L);
+
+    Freshpaint fp = buildFreshpaint(true);
+    fp.trackApplicationLifecycleEvents();
+
+    Properties props = tracksOf(captured).get(0).properties();
+    // DL value must win
+    assertThat(props.get("$gclid")).isEqualTo("DL_GCLID_VALUE");
+    assertThat(props.get("$gclid_creation_time")).isEqualTo(1_000_000L);
+  }
+
+  // -------------------------------------------------------------------------
+  // AC11 (FRP-45) — isFirstOpenTracked() and getDeepLinkAttributionProperties()
+  // -------------------------------------------------------------------------
+
+  /** {@code isFirstOpenTracked()} must return false when the key is absent. */
+  @Test
+  public void isFirstOpenTracked_returnsFalseWhenKeyAbsent() {
+    Freshpaint fp = buildFreshpaint(true);
+    assertThat(fp.isFirstOpenTracked()).isFalse();
+  }
+
+  /**
+   * {@code isFirstOpenTracked()} must return true after {@code trackApplicationLifecycleEvents()}
+   * sets the flag.
+   */
+  @Test
+  public void isFirstOpenTracked_returnsTrueAfterFirstLaunch() {
+    Freshpaint fp = buildFreshpaint(true);
+    fp.trackApplicationLifecycleEvents();
+    assertThat(fp.isFirstOpenTracked()).isTrue();
+  }
+
+  /**
+   * {@code getDeepLinkAttributionProperties()} must return stored DL data from SharedPreferences.
+   */
+  @Test
+  public void getDeepLinkAttributionProperties_returnsStoredDlData() {
+    Map<String, String> dlParams = new LinkedHashMap<>();
+    dlParams.put("gclid", "STORED_GCLID");
+    DeepLinkAttributionManager.store(dlParams, fakePrefs, 1_000_000L);
+
+    Freshpaint fp = buildFreshpaint(true);
+    Map<String, Object> props = fp.getDeepLinkAttributionProperties(1_000_000L);
+    assertThat(props).containsEntry("$gclid", "STORED_GCLID");
+    assertThat(props).containsKey("$gclid_creation_time");
   }
 
   // -------------------------------------------------------------------------

--- a/analytics/src/test/java/io/freshpaint/android/FreshpaintInstallEventTest.java
+++ b/analytics/src/test/java/io/freshpaint/android/FreshpaintInstallEventTest.java
@@ -503,8 +503,9 @@ public class FreshpaintInstallEventTest {
     Properties props = tracksOf(captured).get(0).properties();
     assertThat(props.get("$gclid")).isEqualTo("DL_GCLID_123");
     assertThat(props).containsKey("$gclid_creation_time");
-    // UTM stored at T=1_000_000ms; getStoredProperties called at System.currentTimeMillis()
-    // (>> 1_000_000ms so the UTM window IS expired — see note below). Only asserting click ID.
+    // TODO: FRP-46 — assert UTM params in app_install once clock injection is available.
+    // trackApplicationLifecycleEvents() calls System.currentTimeMillis() (~1.7e12 ms), which
+    // makes the UTM stored at T=1_000_000ms always appear expired. Only asserting click ID here.
   }
 
   /**


### PR DESCRIPTION
## Summary

- Adds `DeepLinkAttributionManager` — a pure-Java static utility that extracts and
  persists 24 ad-platform click IDs, UTM parameters, and `fp_click_id` from Intent
  URI query parameters captured by `trackDeepLink()`.
- Each click ID is stored as `$<id>` with a `$<id>_creation_time` timestamp.
  Dedup logic preserves `creation_time` when the same value is seen again; a new
  value resets it. All five special-mapped keys (`gacid → $gclid_campaign_id`,
  three Facebook fields, `fp_click_id`) follow the same pattern.
- UTM params (`utm_source/medium/campaign/term/content`) are atomically replaced
  per deep link: when any UTM param is present, absent keys are explicitly removed
  so partial updates cannot mix values from different campaigns. UTM data expires
  after 24 hours evaluated at read time; click IDs persist indefinitely.
- `trackDeepLink()` stores attribution via `commit()` (synchronous, ensures
  visibility to the `analyticsExecutor` background thread) then conditionally
  enriches `Deep Link Opened` with stored props when `app_install` has already
  fired.
- `trackApplicationLifecycleEvents()` merges stored DL attribution into
  `app_install` on first install only (`previousBuild == -1`), after Install
  Referrer data. DL values overwrite IR values for overlapping keys (e.g. `$gclid`)
  as the deep link is a more direct signal.
- All SharedPreferences keys use the `dl.` prefix; no collision with `ir.` (FRP-44).

## Files changed

| File | Change |
|------|--------|
| `DeepLinkAttributionManager.java` | New — core storage/retrieval utility |
| `DeepLinkAttributionManagerTest.java` | New — 23 pure-JVM unit tests |
| `AnalyticsActivityLifecycleCallbacks.java` | Extended `trackDeepLink()` |
| `Freshpaint.java` | 3 new `@Private` methods + DL merge in `app_install` path |
| `FreshpaintInstallEventTest.java` | 5 new regression tests (AC10/AC11) |

## Test plan

- [x] `./gradlew :analytics:testDebugUnitTest` — 223 tests, 20 pre-existing
  Robolectric failures (unchanged), 0 new failures
- [x] `./gradlew spotlessCheck` — passes
- [ ] Full `trackDeepLink()` integration test (AC11/AC12 end-to-end) — blocked by
  Robolectric 3.5 / Java 17; tracked for FRP-46
- [ ] UTM-in-`app_install` with injectable clock — tracked for FRP-46