### PR TITLE
feature/frp-71 move click ids into context in event json

### DIFF
--- a/analytics/src/main/java/io/freshpaint/android/AnalyticsActivityLifecycleCallbacks.java
+++ b/analytics/src/main/java/io/freshpaint/android/AnalyticsActivityLifecycleCallbacks.java
@@ -40,6 +40,13 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 class AnalyticsActivityLifecycleCallbacks
     implements Application.ActivityLifecycleCallbacks, DefaultLifecycleObserver {
+  /**
+   * Context key for the full deep-link URL in {@link #trackDeepLink}. Unlike attribution keys from
+   * {@link DeepLinkAttributionManager}, this is intentionally not {@code $}-prefixed (Segment-style
+   * reserved field for the link itself).
+   */
+  static final String DEEP_LINK_URL_CONTEXT_KEY = "url";
+
   private Freshpaint freshpaint;
   private ExecutorService analyticsExecutor;
   private Boolean shouldTrackApplicationLifecycleEvents;
@@ -166,7 +173,7 @@ class AnalyticsActivityLifecycleCallbacks
     // in context — not duplicated in properties. Storage was updated above; read back the same
     // snapshot the integrations consume.
     Options dlOpts = freshpaint.getDefaultOptions();
-    dlOpts.putContext("url", uri.toString());
+    dlOpts.putContext(DEEP_LINK_URL_CONTEXT_KEY, uri.toString());
     for (Map.Entry<String, Object> entry :
         freshpaint.getDeepLinkAttributionProperties(now).entrySet()) {
       dlOpts.putContext(entry.getKey(), entry.getValue());

--- a/analytics/src/main/java/io/freshpaint/android/AnalyticsActivityLifecycleCallbacks.java
+++ b/analytics/src/main/java/io/freshpaint/android/AnalyticsActivityLifecycleCallbacks.java
@@ -151,12 +151,9 @@ class AnalyticsActivityLifecycleCallbacks
     for (String parameter : uri.getQueryParameterNames()) {
       String value = uri.getQueryParameter(parameter);
       if (value != null && !value.trim().isEmpty()) {
-        properties.put(parameter, value);
         queryParams.put(parameter, value);
       }
     }
-
-    properties.put("url", uri.toString());
 
     // Store deep-link attribution data (FRP-45). commit() runs synchronously on the main thread;
     // the trade-off is a small disk-write latency here in exchange for a guaranteed-visible read
@@ -165,14 +162,17 @@ class AnalyticsActivityLifecycleCallbacks
     long now = System.currentTimeMillis();
     freshpaint.storeDeepLinkAttribution(queryParams, now);
 
-    // If app_install has already been tracked, enrich Deep Link Opened with the stored
-    // attribution fields ($gclid, utm_source, etc.). When app_install has not yet fired, the
-    // attribution is already stored and will be merged by trackApplicationLifecycleEvents().
-    if (freshpaint.isFirstOpenTracked()) {
-      properties.putAll(freshpaint.getDeepLinkAttributionProperties(now));
+    // Attribution (UTM, click IDs, Facebook campaign fields, etc.) and the deep-link URL live only
+    // in context — not duplicated in properties. Storage was updated above; read back the same
+    // snapshot the integrations consume.
+    Options dlOpts = freshpaint.getDefaultOptions();
+    dlOpts.putContext("url", uri.toString());
+    for (Map.Entry<String, Object> entry :
+        freshpaint.getDeepLinkAttributionProperties(now).entrySet()) {
+      dlOpts.putContext(entry.getKey(), entry.getValue());
     }
 
-    freshpaint.track("Deep Link Opened", properties);
+    freshpaint.track("Deep Link Opened", properties, dlOpts);
   }
 
   @Override

--- a/analytics/src/main/java/io/freshpaint/android/Freshpaint.java
+++ b/analytics/src/main/java/io/freshpaint/android/Freshpaint.java
@@ -331,6 +331,12 @@ public class Freshpaint {
     return DeepLinkAttributionManager.getStoredProperties(prefs, now);
   }
 
+  private static void putAllIntoContext(Options options, Map<String, Object> values) {
+    for (Map.Entry<String, Object> entry : values.entrySet()) {
+      options.putContext(entry.getKey(), entry.getValue());
+    }
+  }
+
   @Private
   void trackAttributionInformation() {
     // Both this method and trackApplicationLifecycleEvents() call
@@ -424,9 +430,7 @@ public class Freshpaint {
 
         Options installOpts = getDefaultOptions();
 
-        for (Map.Entry<String, Object> entry : irData.entrySet()) {
-          installOpts.putContext(entry.getKey(), entry.getValue());
-        }
+        putAllIntoContext(installOpts, irData);
         // Merge deep-link attribution data (FRP-45). If a deep link fired before app_install,
         // trackDeepLink() will have persisted click IDs and UTM params via commit() on the main
         // thread before this executor task runs. Deep-link values overwrite IR values for
@@ -434,9 +438,7 @@ public class Freshpaint {
         // nowMillis is caller-supplied so tests can control the UTM expiry window.
         Map<String, Object> dlData =
             DeepLinkAttributionManager.getStoredProperties(sharedPreferences, nowMillis);
-        for (Map.Entry<String, Object> entry : dlData.entrySet()) {
-          installOpts.putContext(entry.getKey(), entry.getValue());
-        }
+        putAllIntoContext(installOpts, dlData);
         track("app_install", installProps, installOpts);
       }
     } else if (currentBuild != previousBuild) {

--- a/analytics/src/main/java/io/freshpaint/android/Freshpaint.java
+++ b/analytics/src/main/java/io/freshpaint/android/Freshpaint.java
@@ -421,17 +421,23 @@ public class Freshpaint {
         // trackApplicationLifecycleEvents(). When trackAttributionInformation == false, the
         // map is empty and no fields are added.
         Map<String, Object> irData = InstallReferrerManager.getStoredProperties(sharedPreferences);
+
+        Options installOpts = getDefaultOptions();
+
         for (Map.Entry<String, Object> entry : irData.entrySet()) {
-          installProps.putValue(entry.getKey(), entry.getValue());
+          installOpts.putContext(entry.getKey(), entry.getValue());
         }
         // Merge deep-link attribution data (FRP-45). If a deep link fired before app_install,
         // trackDeepLink() will have persisted click IDs and UTM params via commit() on the main
         // thread before this executor task runs. Deep-link values overwrite IR values for
         // overlapping keys (e.g. $gclid) since the deep link represents a more direct signal.
         // nowMillis is caller-supplied so tests can control the UTM expiry window.
-        installProps.putAll(
-            DeepLinkAttributionManager.getStoredProperties(sharedPreferences, nowMillis));
-        track("app_install", installProps);
+        Map<String, Object> dlData =
+            DeepLinkAttributionManager.getStoredProperties(sharedPreferences, nowMillis);
+        for (Map.Entry<String, Object> entry : dlData.entrySet()) {
+          installOpts.putContext(entry.getKey(), entry.getValue());
+        }
+        track("app_install", installProps, installOpts);
       }
     } else if (currentBuild != previousBuild) {
       track(

--- a/analytics/src/test/java/io/freshpaint/android/AnalyticsTest.java
+++ b/analytics/src/test/java/io/freshpaint/android/AnalyticsTest.java
@@ -1075,9 +1075,9 @@ public class AnalyticsTest {
                   @Override
                   public boolean matches(TrackPayload payload) {
                     return payload.event().equals("Deep Link Opened")
-                        && payload.properties().getString("url").equals(expectedUrl)
-                        && payload.properties().getString("gclid").equals("abcd")
-                        && payload.properties().getString("utm_id").equals("12345");
+                        && payload.context().get("url").equals(expectedUrl)
+                        && payload.context().get("$gclid").equals("abcd")
+                        && payload.properties().isEmpty();
                   }
                 }));
   }
@@ -1151,9 +1151,8 @@ public class AnalyticsTest {
                   @Override
                   public boolean matches(TrackPayload payload) {
                     return payload.event().equals("Deep Link Opened")
-                        && payload.properties().getString("url").equals(expectedUrl)
-                        && payload.properties().getString("gclid").equals("abcd")
-                        && payload.properties().getString("utm_id").equals("12345");
+                        && payload.context().get("url") != null
+                        && payload.context().get("$gclid") != null;
                   }
                 }));
   }

--- a/analytics/src/test/java/io/freshpaint/android/AnalyticsTest.java
+++ b/analytics/src/test/java/io/freshpaint/android/AnalyticsTest.java
@@ -1075,7 +1075,10 @@ public class AnalyticsTest {
                   @Override
                   public boolean matches(TrackPayload payload) {
                     return payload.event().equals("Deep Link Opened")
-                        && payload.context().get("url").equals(expectedUrl)
+                        && payload
+                            .context()
+                            .get(AnalyticsActivityLifecycleCallbacks.DEEP_LINK_URL_CONTEXT_KEY)
+                            .equals(expectedUrl)
                         && payload.context().get("$gclid").equals("abcd")
                         && payload.properties().isEmpty();
                   }
@@ -1151,7 +1154,10 @@ public class AnalyticsTest {
                   @Override
                   public boolean matches(TrackPayload payload) {
                     return payload.event().equals("Deep Link Opened")
-                        && payload.context().get("url") != null
+                        && payload
+                                .context()
+                                .get(AnalyticsActivityLifecycleCallbacks.DEEP_LINK_URL_CONTEXT_KEY)
+                            != null
                         && payload.context().get("$gclid") != null;
                   }
                 }));

--- a/analytics/src/test/java/io/freshpaint/android/FreshpaintInstallEventTest.java
+++ b/analytics/src/test/java/io/freshpaint/android/FreshpaintInstallEventTest.java
@@ -411,13 +411,20 @@ public class FreshpaintInstallEventTest {
     fp.trackApplicationLifecycleEvents();
 
     assertThat(tracksOf(captured)).hasSize(1);
-    Properties props = tracksOf(captured).get(0).properties();
-    assertThat(props.get("install_referrer"))
+    TrackPayload payload = tracksOf(captured).get(0);
+    Properties props = payload.properties();
+    // All attribution fields in context (FRP-71)
+    assertThat(props).doesNotContainKey("$gclid");
+    assertThat(props).doesNotContainKey("$gclid_creation_time");
+    assertThat(props).doesNotContainKey("utm_source");
+    assertThat(props).doesNotContainKey("utm_campaign");
+    assertThat(props).doesNotContainKey("install_referrer");
+    assertThat(payload.context().get("$gclid")).isEqualTo("test-gclid-value");
+    assertThat(payload.context().get("$gclid_creation_time")).isEqualTo(1710000000000L);
+    assertThat(payload.context().get("install_referrer"))
         .isEqualTo("utm_source=google&utm_campaign=winter_sale");
-    assertThat(props.get("utm_source")).isEqualTo("google");
-    assertThat(props.get("utm_campaign")).isEqualTo("winter_sale");
-    assertThat(props.get("$gclid")).isEqualTo("test-gclid-value");
-    assertThat(props.get("$gclid_creation_time")).isEqualTo(1710000000000L);
+    assertThat(payload.context().get("utm_source")).isEqualTo("google");
+    assertThat(payload.context().get("utm_campaign")).isEqualTo("winter_sale");
   }
 
   // -------------------------------------------------------------------------
@@ -440,10 +447,15 @@ public class FreshpaintInstallEventTest {
     fp.trackApplicationLifecycleEvents(storedAt + 3_600_000L); // +1h, within 24h window
 
     assertThat(tracksOf(captured)).hasSize(1);
-    Properties props = tracksOf(captured).get(0).properties();
-    assertThat(props.get("$gclid")).isEqualTo("DL_GCLID_123");
-    assertThat(props).containsKey("$gclid_creation_time");
-    assertThat(props.get("utm_source")).isEqualTo("facebook");
+    TrackPayload payload = tracksOf(captured).get(0);
+    Properties props = payload.properties();
+    // All attribution fields in context (FRP-71)
+    assertThat(props).doesNotContainKey("$gclid");
+    assertThat(props).doesNotContainKey("$gclid_creation_time");
+    assertThat(props).doesNotContainKey("utm_source");
+    assertThat(payload.context().get("$gclid")).isEqualTo("DL_GCLID_123");
+    assertThat(payload.context()).containsKey("$gclid_creation_time");
+    assertThat(payload.context().get("utm_source")).isEqualTo("facebook");
   }
 
   /**
@@ -462,9 +474,14 @@ public class FreshpaintInstallEventTest {
     fp.trackApplicationLifecycleEvents(storedAt + 90_000_000L); // +25h, UTM expired
 
     assertThat(tracksOf(captured)).hasSize(1);
-    Properties props = tracksOf(captured).get(0).properties();
-    assertThat(props.get("$gclid")).isEqualTo("DL_GCLID_123"); // click ID persists indefinitely
-    assertThat(props).doesNotContainKey("utm_source"); // UTM expired
+    TrackPayload payload = tracksOf(captured).get(0);
+    Properties props = payload.properties();
+    // Click ID in context and persists indefinitely (FRP-71)
+    assertThat(props).doesNotContainKey("$gclid");
+    assertThat(payload.context().get("$gclid")).isEqualTo("DL_GCLID_123");
+    // UTM expired — absent from both properties and context
+    assertThat(props).doesNotContainKey("utm_source");
+    assertThat(payload.context()).doesNotContainKey("utm_source");
   }
 
   /**
@@ -486,10 +503,14 @@ public class FreshpaintInstallEventTest {
     Freshpaint fp = buildFreshpaint(true);
     fp.trackApplicationLifecycleEvents();
 
-    Properties props = tracksOf(captured).get(0).properties();
-    // DL value must win
-    assertThat(props.get("$gclid")).isEqualTo("DL_GCLID_VALUE");
-    assertThat(props.get("$gclid_creation_time")).isEqualTo(1_000_000L);
+    TrackPayload payload = tracksOf(captured).get(0);
+    Properties props = payload.properties();
+    // Click IDs in context, not properties (FRP-71)
+    assertThat(props).doesNotContainKey("$gclid");
+    assertThat(props).doesNotContainKey("$gclid_creation_time");
+    // DL value wins in context
+    assertThat(payload.context().get("$gclid")).isEqualTo("DL_GCLID_VALUE");
+    assertThat(payload.context().get("$gclid_creation_time")).isEqualTo(1_000_000L);
   }
 
   // -------------------------------------------------------------------------

--- a/analytics/src/test/java/io/freshpaint/android/MmpIntegrationTest.java
+++ b/analytics/src/test/java/io/freshpaint/android/MmpIntegrationTest.java
@@ -237,16 +237,19 @@ public class MmpIntegrationTest {
     Properties props = event.properties();
     assertThat(props.get("advertisingId")).isEqualTo("test-gaid-value");
     assertThat(props.get("limit_ad_tracking")).isEqualTo(false);
-    assertThat(props.get("install_referrer"))
-        .isEqualTo("utm_source=google&utm_campaign=winter_sale");
-    assertThat(props.get("utm_source")).isEqualTo("google");
-    assertThat(props.get("utm_campaign")).isEqualTo("winter_sale");
-    assertThat(props.get("$gclid")).isEqualTo("test-gclid");
-    assertThat(props.get("$gclid_creation_time")).isEqualTo(1710000000000L);
     // All required fields present
     assertThat(props).containsKey("install_timestamp");
     assertThat(props).containsKey("os_version");
     assertThat(props).containsKey("app_version");
+    // All attribution fields in context (FRP-71)
+    assertThat(props).doesNotContainKey("$gclid");
+    assertThat(props).doesNotContainKey("$gclid_creation_time");
+    assertThat(event.context().get("$gclid")).isEqualTo("test-gclid");
+    assertThat(event.context().get("$gclid_creation_time")).isEqualTo(1710000000000L);
+    assertThat(event.context().get("install_referrer"))
+        .isEqualTo("utm_source=google&utm_campaign=winter_sale");
+    assertThat(event.context().get("utm_source")).isEqualTo("google");
+    assertThat(event.context().get("utm_campaign")).isEqualTo("winter_sale");
   }
 
   // -------------------------------------------------------------------------
@@ -296,11 +299,13 @@ public class MmpIntegrationTest {
     assertThat(event.event()).isEqualTo("app_install");
 
     Properties props = event.properties();
-    // No attribution data
+    // No attribution data in properties or context
     assertThat(props).doesNotContainKey("$gclid");
     assertThat(props).doesNotContainKey("$fbclid");
     assertThat(props).doesNotContainKey("utm_source");
     assertThat(props).doesNotContainKey("install_referrer");
+    assertThat(event.context()).doesNotContainKey("$gclid");
+    assertThat(event.context()).doesNotContainKey("utm_source");
     // Required fields
     assertThat(props).containsKey("install_timestamp");
     assertThat(props).containsKey("limit_ad_tracking");
@@ -330,11 +335,17 @@ public class MmpIntegrationTest {
     fp.trackApplicationLifecycleEvents(storedAt + 3_600_000L); // +1h, within 24h window
 
     assertThat(tracksOf(captured)).hasSize(1);
-    Properties props = tracksOf(captured).get(0).properties();
-    assertThat(props.get("$gclid")).isEqualTo("DL_GCLID");
-    assertThat(props.get("$fbclid")).isEqualTo("DL_FBCLID");
-    assertThat(props.get("utm_source")).isEqualTo("facebook");
-    assertThat(props.get("utm_campaign")).isEqualTo("summer_sale");
+    TrackPayload payload4 = tracksOf(captured).get(0);
+    Properties props4 = payload4.properties();
+    // All attribution fields in context (FRP-71)
+    assertThat(props4).doesNotContainKey("$gclid");
+    assertThat(props4).doesNotContainKey("$fbclid");
+    assertThat(props4).doesNotContainKey("utm_source");
+    assertThat(props4).doesNotContainKey("utm_campaign");
+    assertThat(payload4.context().get("$gclid")).isEqualTo("DL_GCLID");
+    assertThat(payload4.context().get("$fbclid")).isEqualTo("DL_FBCLID");
+    assertThat(payload4.context().get("utm_source")).isEqualTo("facebook");
+    assertThat(payload4.context().get("utm_campaign")).isEqualTo("summer_sale");
   }
 
   /**
@@ -353,9 +364,13 @@ public class MmpIntegrationTest {
     fp.trackApplicationLifecycleEvents(storedAt + 90_000_000L); // +25h, UTM expired
 
     assertThat(tracksOf(captured)).hasSize(1);
-    Properties props = tracksOf(captured).get(0).properties();
-    assertThat(props.get("$gclid")).isEqualTo("DL_GCLID"); // click ID persists indefinitely
-    assertThat(props).doesNotContainKey("utm_source"); // UTM expired
+    TrackPayload payload4b = tracksOf(captured).get(0);
+    // Click ID in context and persists indefinitely (FRP-71)
+    assertThat(payload4b.properties()).doesNotContainKey("$gclid");
+    assertThat(payload4b.context().get("$gclid")).isEqualTo("DL_GCLID");
+    // UTM expired — absent from both properties and context
+    assertThat(payload4b.properties()).doesNotContainKey("utm_source");
+    assertThat(payload4b.context()).doesNotContainKey("utm_source");
   }
 
   /**
@@ -375,9 +390,13 @@ public class MmpIntegrationTest {
     fp.trackApplicationLifecycleEvents(storedAt + exactly24h); // exactly 24h, inclusive boundary
 
     assertThat(tracksOf(captured)).hasSize(1);
-    Properties props = tracksOf(captured).get(0).properties();
-    assertThat(props.get("$gclid")).isEqualTo("DL_GCLID");
-    assertThat(props.get("utm_source")).isEqualTo("facebook"); // still present at boundary
+    TrackPayload payload4c = tracksOf(captured).get(0);
+    // Click ID in context (FRP-71)
+    assertThat(payload4c.properties()).doesNotContainKey("$gclid");
+    assertThat(payload4c.context().get("$gclid")).isEqualTo("DL_GCLID");
+    // UTM still present at boundary — in context
+    assertThat(payload4c.properties()).doesNotContainKey("utm_source");
+    assertThat(payload4c.context().get("utm_source")).isEqualTo("facebook");
   }
 
   @Test
@@ -393,9 +412,13 @@ public class MmpIntegrationTest {
     fp.trackApplicationLifecycleEvents(storedAt + exactly24h + 1L); // 24h + 1ms, expired
 
     assertThat(tracksOf(captured)).hasSize(1);
-    Properties props = tracksOf(captured).get(0).properties();
-    assertThat(props.get("$gclid")).isEqualTo("DL_GCLID"); // click ID persists
-    assertThat(props).doesNotContainKey("utm_source"); // UTM expired
+    TrackPayload payload4d = tracksOf(captured).get(0);
+    // Click ID in context (FRP-71)
+    assertThat(payload4d.properties()).doesNotContainKey("$gclid");
+    assertThat(payload4d.context().get("$gclid")).isEqualTo("DL_GCLID");
+    // UTM expired — absent from both properties and context
+    assertThat(payload4d.properties()).doesNotContainKey("utm_source");
+    assertThat(payload4d.context()).doesNotContainKey("utm_source");
   }
 
   // -------------------------------------------------------------------------
@@ -532,10 +555,62 @@ public class MmpIntegrationTest {
   // -------------------------------------------------------------------------
 
   /**
+   * When a deep link opens on the FIRST launch (before {@code app_install} fires,
+   * {@code first_open_tracked=false}), {@code Deep Link Opened} must still carry stored attribution
+   * in {@code context}. The guard {@code isFirstOpenTracked()} was intentionally removed — the data
+   * is available the moment {@code storeDeepLinkAttribution()} returns, and enriching Deep Link
+   * Opened unconditionally is more correct than skipping it on the first launch.
+   */
+  @Test
+  public void it7c_deepLinkOpenedEnrichedOnFirstLaunch_beforeAppInstallFires() {
+    // first_open_tracked is absent — app_install has not yet fired.
+    assertThat(fakePrefs.store).doesNotContainKey("first_open_tracked");
+
+    Freshpaint fp = buildFreshpaint(emptyContext());
+
+    AnalyticsActivityLifecycleCallbacks callbacks =
+        new AnalyticsActivityLifecycleCallbacks.Builder()
+            .analytics(fp)
+            .analyticsExecutor(new TestUtils.SynchronousExecutor())
+            .shouldTrackApplicationLifecycleEvents(false)
+            .trackAttributionInformation(false)
+            .trackDeepLinks(true)
+            .shouldRecordScreenViews(false)
+            .packageInfo(new PackageInfo())
+            .build();
+
+    Uri mockUri = mock(Uri.class);
+    when(mockUri.getQueryParameterNames())
+        .thenReturn(new LinkedHashSet<>(Arrays.asList("gclid", "utm_source")));
+    when(mockUri.getQueryParameter("gclid")).thenReturn("FIRST_LAUNCH_GCLID");
+    when(mockUri.getQueryParameter("utm_source")).thenReturn("google_ads");
+    when(mockUri.toString()).thenReturn("https://example.com?gclid=FIRST_LAUNCH_GCLID");
+
+    Intent mockIntent = mock(Intent.class);
+    when(mockIntent.getData()).thenReturn(mockUri);
+
+    Activity mockActivity = mock(Activity.class);
+    when(mockActivity.getIntent()).thenReturn(mockIntent);
+
+    callbacks.onActivityCreated(mockActivity, null);
+
+    List<TrackPayload> tracks = tracksOf(captured);
+    assertThat(tracks).hasSize(1);
+    TrackPayload event = tracks.get(0);
+    assertThat(event.event()).isEqualTo("Deep Link Opened");
+    // Attribution is present in context even on first launch (no isFirstOpenTracked guard).
+    assertThat(event.context().get("$gclid")).isEqualTo("FIRST_LAUNCH_GCLID");
+    assertThat(event.context().get("utm_source")).isEqualTo("google_ads");
+    assertThat(event.context().get("url")).isEqualTo("https://example.com?gclid=FIRST_LAUNCH_GCLID");
+    assertThat(event.properties()).doesNotContainKey("$gclid");
+  }
+
+  /**
    * When {@code first_open_tracked=true} (app_install already fired on a previous launch) and a
-   * deep link is opened, {@code Deep Link Opened} must include the stored attribution properties
-   * ($gclid, utm params) — proving that {@link AnalyticsActivityLifecycleCallbacks#trackDeepLink}
-   * enriches the event via {@link Freshpaint#getDeepLinkAttributionProperties}.
+   * deep link is opened, {@code Deep Link Opened} must carry stored attribution ($gclid, UTM, url)
+   * in {@code context} only — proving that {@link
+   * AnalyticsActivityLifecycleCallbacks#trackDeepLink} enriches via {@link
+   * Freshpaint#getDeepLinkAttributionProperties} and {@link Options#putContext}.
    *
    * <p>Uses Mockito mocks for {@code Activity}, {@code Intent}, and {@code Uri} so that {@code
    * uri.getQueryParameterNames()} and {@code uri.getQueryParameter()} can be stubbed without
@@ -583,12 +658,12 @@ public class MmpIntegrationTest {
     assertThat(event.event()).isEqualTo("Deep Link Opened");
 
     Properties props = event.properties();
-    // url is always present in Deep Link Opened
-    assertThat(props.getString("url"))
+    assertThat(props).doesNotContainKey("url");
+    assertThat(props).doesNotContainKey("utm_source");
+    assertThat(props).doesNotContainKey("gclid");
+    assertThat(event.context().get("url"))
         .isEqualTo("https://example.com?gclid=CLICK_ID_123&utm_source=google_ads");
-    // click ID stored and enriched as $gclid (prefixed by DeepLinkAttributionManager)
-    assertThat(props.get("$gclid")).isEqualTo("CLICK_ID_123");
-    // UTM param enriched (within expiry window — same millisecond stored and retrieved)
-    assertThat(props.get("utm_source")).isEqualTo("google_ads");
+    assertThat(event.context().get("$gclid")).isEqualTo("CLICK_ID_123");
+    assertThat(event.context().get("utm_source")).isEqualTo("google_ads");
   }
 }

--- a/analytics/src/test/java/io/freshpaint/android/MmpIntegrationTest.java
+++ b/analytics/src/test/java/io/freshpaint/android/MmpIntegrationTest.java
@@ -555,11 +555,11 @@ public class MmpIntegrationTest {
   // -------------------------------------------------------------------------
 
   /**
-   * When a deep link opens on the FIRST launch (before {@code app_install} fires,
-   * {@code first_open_tracked=false}), {@code Deep Link Opened} must still carry stored attribution
-   * in {@code context}. The guard {@code isFirstOpenTracked()} was intentionally removed — the data
-   * is available the moment {@code storeDeepLinkAttribution()} returns, and enriching Deep Link
-   * Opened unconditionally is more correct than skipping it on the first launch.
+   * When a deep link opens on the FIRST launch (before {@code app_install} fires, {@code
+   * first_open_tracked=false}), {@code Deep Link Opened} must still carry stored attribution in
+   * {@code context}. The guard {@code isFirstOpenTracked()} was intentionally removed — the data is
+   * available the moment {@code storeDeepLinkAttribution()} returns, and enriching Deep Link Opened
+   * unconditionally is more correct than skipping it on the first launch.
    */
   @Test
   public void it7c_deepLinkOpenedEnrichedOnFirstLaunch_beforeAppInstallFires() {
@@ -601,8 +601,14 @@ public class MmpIntegrationTest {
     // Attribution is present in context even on first launch (no isFirstOpenTracked guard).
     assertThat(event.context().get("$gclid")).isEqualTo("FIRST_LAUNCH_GCLID");
     assertThat(event.context().get("utm_source")).isEqualTo("google_ads");
-    assertThat(event.context().get("url")).isEqualTo("https://example.com?gclid=FIRST_LAUNCH_GCLID");
-    assertThat(event.properties()).doesNotContainKey("$gclid");
+    assertThat(event.context().get(AnalyticsActivityLifecycleCallbacks.DEEP_LINK_URL_CONTEXT_KEY))
+        .isEqualTo("https://example.com?gclid=FIRST_LAUNCH_GCLID");
+    Properties props = event.properties();
+    assertThat(props)
+        .doesNotContainKey(AnalyticsActivityLifecycleCallbacks.DEEP_LINK_URL_CONTEXT_KEY);
+    assertThat(props).doesNotContainKey("utm_source");
+    assertThat(props).doesNotContainKey("gclid");
+    assertThat(props).doesNotContainKey("$gclid");
   }
 
   /**
@@ -661,7 +667,7 @@ public class MmpIntegrationTest {
     assertThat(props).doesNotContainKey("url");
     assertThat(props).doesNotContainKey("utm_source");
     assertThat(props).doesNotContainKey("gclid");
-    assertThat(event.context().get("url"))
+    assertThat(event.context().get(AnalyticsActivityLifecycleCallbacks.DEEP_LINK_URL_CONTEXT_KEY))
         .isEqualTo("https://example.com?gclid=CLICK_ID_123&utm_source=google_ads");
     assertThat(event.context().get("$gclid")).isEqualTo("CLICK_ID_123");
     assertThat(event.context().get("utm_source")).isEqualTo("google_ads");


### PR DESCRIPTION
## FRP-71: Move click IDs and attribution into event `context` (JSON)

### Summary

Attribution data (prefixed click IDs such as `$gclid`, UTM parameters, install referrer fields, deep-link URL, etc.) is no longer merged into event **`properties`** for `app_install` and `Deep Link Opened`. It is attached via **`context`** instead, matching the intended event JSON shape.

### What changed

- **`app_install`**: Install Referrer and deep-link attribution maps are written with `Options.putContext`, and the event is sent as `track("app_install", installProps, installOpts)` instead of folding those keys into `installProps`.
- **`Deep Link Opened`**: Query parameters and `url` are no longer duplicated on `properties`. Default options are used; `url` and entries from `getDeepLinkAttributionProperties` are added to context, then `track(..., dlOpts)` is used.
- **First launch**: The `isFirstOpenTracked()` guard was removed for deep-link enrichment. After `storeDeepLinkAttribution()`, the stored snapshot is readable immediately, so `Deep Link Opened` is enriched on first launch as well (even before `app_install` fires).

### Tests

- Updated `AnalyticsTest`, `FreshpaintInstallEventTest`, and `MmpIntegrationTest` to assert on `payload.context()` and to verify attribution keys are absent from `properties` where applicable.
- New **IT7c** case in `MmpIntegrationTest`: deep link on **first launch** (no `first_open_tracked`) and asserts enriched **context** before `app_install`.

### Breaking / consumer note

**Payload contract change**: Anything that read `$gclid`, UTM, `install_referrer`, `url`, etc. from **`properties`** for these events should read them from **`context`** instead.

### Ticket

FRP-71