### PR TITLE
FRP-80 restore Application Installed name and version/build fields

### DIFF
--- a/analytics/src/main/java/io/freshpaint/android/AnalyticsActivityLifecycleCallbacks.java
+++ b/analytics/src/main/java/io/freshpaint/android/AnalyticsActivityLifecycleCallbacks.java
@@ -162,7 +162,7 @@ class AnalyticsActivityLifecycleCallbacks
       }
     }
 
-    // Store deep-link attribution data (FRP-45). commit() runs synchronously on the main thread;
+    // Store deep-link attribution data. commit() runs synchronously on the main thread;
     // the trade-off is a small disk-write latency here in exchange for a guaranteed-visible read
     // on the analyticsExecutor thread. apply() cannot substitute: the executor may be scheduled
     // before apply()'s async flush completes, leaving getStoredProperties() reading stale data.

--- a/analytics/src/main/java/io/freshpaint/android/AttributionConstants.java
+++ b/analytics/src/main/java/io/freshpaint/android/AttributionConstants.java
@@ -26,7 +26,7 @@ package io.freshpaint.android;
 import androidx.annotation.Nullable;
 
 /**
- * Shared attribution constants used by Install Referrer (FRP-44) and deep-link attribution
+ * Shared attribution constants used by Install Referrer and deep-link attribution
  * Centralising the click-id list here ensures both sources use the same set and prevents
  * divergence.
  */

--- a/analytics/src/main/java/io/freshpaint/android/AttributionMiddleware.java
+++ b/analytics/src/main/java/io/freshpaint/android/AttributionMiddleware.java
@@ -33,11 +33,11 @@ import io.freshpaint.android.integrations.TrackPayload;
  * fetched, {@code null} is used and event dispatch is never blocked.
  *
  * <p>For {@link TrackPayload}s that already include {@code limit_ad_tracking} in {@code properties}
- * (e.g. {@code app_install}), this value is overwritten to match {@code
+ * (e.g. {@code Application Installed}), this value is overwritten to match {@code
  * context.device.limit_ad_tracking} so it cannot disagree with the device block after the GAID
  * worker has updated the context.
  *
- * <p>For {@code app_install} only, {@code properties.advertisingId} is set or updated from the live
+ * <p>For {@code Application Installed} only, {@code properties.advertisingId} is set or updated from the live
  * device map when available at dispatch time (same key as {@code context.device}), matching the
  * {@code limit_ad_tracking} fix (snapshot at {@code track()} vs live device at middleware).
  */
@@ -47,7 +47,7 @@ class AttributionMiddleware implements Middleware {
   private static final String TRACK_PROPERTIES_KEY = "properties";
 
   /** Event name for first-open install track; {@code properties.advertisingId} is reconciled. */
-  private static final String APP_INSTALL_EVENT = "app_install";
+  private static final String APP_INSTALL_EVENT = "Application Installed";
 
   private final AnalyticsContext analyticsContext;
 

--- a/analytics/src/main/java/io/freshpaint/android/DeepLinkAttributionManager.java
+++ b/analytics/src/main/java/io/freshpaint/android/DeepLinkAttributionManager.java
@@ -35,7 +35,7 @@ import java.util.Map;
  * AnalyticsActivityLifecycleCallbacks#trackDeepLink}.
  *
  * <p>All SharedPreferences keys use the {@code "dl."} prefix to avoid collisions with the Install
- * Referrer namespace ({@code "ir."} from FRP-44).
+ * Referrer namespace ({@code "ir."}).
  *
  * <p>Click IDs persist indefinitely. UTM parameters expire after 24 hours; expiry is evaluated at
  * read time using a caller-supplied {@code now} timestamp to keep the class testable without mocks.
@@ -45,7 +45,7 @@ import java.util.Map;
  * <p><b>Naming convention:</b> all ad-platform click IDs are stored and returned with a {@code $}
  * prefix (e.g. {@code $gclid}, {@code $fbclid}). The Freshpaint-native click ID ({@code
  * fp_click_id}) is stored and returned <em>without</em> the {@code $} prefix, matching the Install
- * Referrer convention established in FRP-44.
+ * Referrer convention.
  */
 final class DeepLinkAttributionManager {
 

--- a/analytics/src/main/java/io/freshpaint/android/Freshpaint.java
+++ b/analytics/src/main/java/io/freshpaint/android/Freshpaint.java
@@ -134,7 +134,7 @@ public class Freshpaint {
 
   @Private final boolean nanosecondTimestamps;
 
-  // Whether to fire the app_install (first-open) event on first launch. Set by Builder.
+  // Whether to fire the Application Installed (first-open) event on first launch. Set by Builder.
   @Private final boolean trackFirstOpen;
 
   /**
@@ -296,7 +296,7 @@ public class Freshpaint {
   }
 
   // -------------------------------------------------------------------------
-  // Deep-link attribution (FRP-45)
+  // Deep-link attribution
   // -------------------------------------------------------------------------
 
   /**
@@ -312,8 +312,8 @@ public class Freshpaint {
   }
 
   /**
-   * Returns {@code true} if the {@code app_install} first-open event has already been tracked (i.e.
-   * {@code FIRST_OPEN_TRACKED_KEY} is set in SharedPreferences).
+   * Returns {@code true} if the {@code Application Installed} first-open event has already been
+   * tracked (i.e. {@code FIRST_OPEN_TRACKED_KEY} is set in SharedPreferences).
    */
   @Private
   boolean isFirstOpenTracked() {
@@ -367,8 +367,8 @@ public class Freshpaint {
   /**
    * Package-private overload that accepts a caller-supplied {@code nowMillis} timestamp. The no-arg
    * public method delegates here with {@link System#currentTimeMillis()}. Exposed for tests that
-   * need to control the clock (e.g. to assert UTM expiry in the {@code app_install} payload without
-   * depending on wall-clock time).
+   * need to control the clock (e.g. to assert UTM expiry in the {@code Application Installed}
+   * payload without depending on wall-clock time).
    */
   @VisibleForTesting
   void trackApplicationLifecycleEvents(long nowMillis) {
@@ -383,7 +383,7 @@ public class Freshpaint {
     int previousBuild = sharedPreferences.getInt(BUILD_KEY, -1);
     boolean firstOpenTracked = sharedPreferences.getBoolean(FIRST_OPEN_TRACKED_KEY, false);
 
-    // Check and track app_install (first install) or Application Updated.
+    // Check and track Application Installed (first install) or Application Updated.
     if (previousBuild == -1) {
       if (trackFirstOpen && !firstOpenTracked) {
         AnalyticsContext.Device device = analyticsContext.device();
@@ -409,7 +409,8 @@ public class Freshpaint {
                 // properties.limit_ad_tracking with context.device on dispatch.
                 .putValue("limit_ad_tracking", limitAdTracking)
                 .putValue("os_version", Build.VERSION.RELEASE)
-                .putValue("app_version", currentVersion);
+                .putValue("version", currentVersion)
+                .putValue("build", String.valueOf(currentBuild));
         // Omit advertisingId when not yet resolved: explicit null vs. absent key are handled
         // differently by some MMP backends. AttributionMiddleware reconciles
         // properties.advertisingId with context.device at dispatch when the GAID worker completes.
@@ -431,15 +432,15 @@ public class Freshpaint {
         Options installOpts = getDefaultOptions();
 
         putAllIntoContext(installOpts, irData);
-        // Merge deep-link attribution data (FRP-45). If a deep link fired before app_install,
-        // trackDeepLink() will have persisted click IDs and UTM params via commit() on the main
-        // thread before this executor task runs. Deep-link values overwrite IR values for
+        // Merge deep-link attribution data. If a deep link fired before Application
+        // Installed, trackDeepLink() will have persisted click IDs and UTM params via commit() on
+        // the main thread before this executor task runs. Deep-link values overwrite IR values for
         // overlapping keys (e.g. $gclid) since the deep link represents a more direct signal.
         // nowMillis is caller-supplied so tests can control the UTM expiry window.
         Map<String, Object> dlData =
             DeepLinkAttributionManager.getStoredProperties(sharedPreferences, nowMillis);
         putAllIntoContext(installOpts, dlData);
-        track("app_install", installProps, installOpts);
+        track("Application Installed", installProps, installOpts);
       }
     } else if (currentBuild != previousBuild) {
       track(
@@ -457,7 +458,7 @@ public class Freshpaint {
     editor.putInt(BUILD_KEY, currentBuild);
     // Written on every path (fresh install, upgrade, subsequent launch) so that upgrade-path
     // users who skip previousBuild==-1 are also guarded against future re-fires. This key means
-    // "app_install will not fire again", not "app_install was fired on this device".
+    // "Application Installed will not fire again", not "Application Installed was fired on this device".
     editor.putBoolean(FIRST_OPEN_TRACKED_KEY, true);
     // apply() updates the in-memory SharedPreferences cache synchronously before returning, so
     // isFirstOpenTracked() reads the new value immediately on the same thread. The async disk
@@ -958,9 +959,9 @@ public class Freshpaint {
   public void reset() {
     SharedPreferences sharedPreferences = Utils.getFreshpaintSharedPreferences(application, tag);
     // LIB-1578: only remove traits, preserve BUILD, VERSION, and FIRST_OPEN_TRACKED keys in order
-    // to fix over-sending of 'app_install' events and under-sending of 'Application Updated'
-    // events. FIRST_OPEN_TRACKED_KEY is intentionally preserved so that app_install is not
-    // re-fired after a user reset (matching the original Application Installed behavior).
+    // to fix over-sending of 'Application Installed' events and under-sending of 'Application Updated'
+    // events. FIRST_OPEN_TRACKED_KEY is intentionally preserved so that Application Installed is not
+    // re-fired after a user reset (matching the original Segment SDK behavior).
     SharedPreferences.Editor editor = sharedPreferences.edit();
     editor.remove(TRAITS_KEY + "-" + tag);
     editor.apply();
@@ -1348,7 +1349,7 @@ public class Freshpaint {
     }
 
     /**
-     * Automatically track application lifecycle events, including "app_install" (first-open),
+     * Automatically track application lifecycle events, including "Application Installed" (first-open),
      * "Application Updated" and "Application Opened".
      */
     public Builder trackApplicationLifecycleEvents() {
@@ -1375,8 +1376,8 @@ public class Freshpaint {
     }
 
     /**
-     * Enable or disable firing the first-open install event ({@code app_install}) on the initial
-     * launch. Enabled by default.
+     * Enable or disable firing the first-open install event ({@code Application Installed}) on the
+     * initial launch. Enabled by default.
      */
     public Builder trackFirstOpen(boolean trackFirstOpen) {
       this.trackFirstOpen = trackFirstOpen;

--- a/analytics/src/test/java/io/freshpaint/android/AnalyticsLifecycleCallbacksAttributionTest.java
+++ b/analytics/src/test/java/io/freshpaint/android/AnalyticsLifecycleCallbacksAttributionTest.java
@@ -40,15 +40,15 @@ import org.mockito.InOrder;
  * Pure-JVM tests for the combined executor task in {@link
  * AnalyticsActivityLifecycleCallbacks#onCreate}. No Robolectric required.
  *
- * <p>REG1 — {@code trackAttributionInformation()} runs before {@code
+ * <p>{@code trackAttributionInformation()} runs before {@code
  * trackApplicationLifecycleEvents()} when attribution is enabled.
  *
- * <p>REG2 — {@code trackApplicationLifecycleEvents()} fires directly (not via executor) and {@code
+ * <p>{@code trackApplicationLifecycleEvents()} fires directly (not via executor) and {@code
  * trackAttributionInformation()} is never called when attribution is disabled.
  *
- * <p>REG3 — when {@code trackAttributionInformation()} throws, {@code
- * trackApplicationLifecycleEvents()} still fires and the exception is logged (FRP-57).
- */
+ * <p>when {@code trackAttributionInformation()} throws, {@code
+ * trackApplicationLifecycleEvents()} still fires and the exception is logged.
+ */ 
 public class AnalyticsLifecycleCallbacksAttributionTest {
 
   private AnalyticsActivityLifecycleCallbacks buildCallbacks(
@@ -65,7 +65,7 @@ public class AnalyticsLifecycleCallbacksAttributionTest {
   }
 
   // -------------------------------------------------------------------------
-  // REG1 — trackAttributionInformation executes before trackApplicationLifecycleEvents
+  // trackAttributionInformation executes before trackApplicationLifecycleEvents
   // -------------------------------------------------------------------------
 
   /**
@@ -87,7 +87,7 @@ public class AnalyticsLifecycleCallbacksAttributionTest {
   }
 
   // -------------------------------------------------------------------------
-  // REG3 — attribution throws → lifecycle events still fire; exception is logged
+  // attribution throws → lifecycle events still fire; exception is logged
   // -------------------------------------------------------------------------
 
   /**
@@ -107,9 +107,9 @@ public class AnalyticsLifecycleCallbacksAttributionTest {
     AnalyticsActivityLifecycleCallbacks callbacks = buildCallbacks(mockFreshpaint, true);
     callbacks.onCreate(mock(LifecycleOwner.class));
 
-    // Lifecycle events must fire despite the attribution exception (AC2, AC6).
+    // Lifecycle events must fire despite the attribution exception.
     verify(mockFreshpaint).trackApplicationLifecycleEvents();
-    // Exception must be logged — not silently dropped (AC3).
+    // Exception must be logged — not silently dropped.
     verify(mockLogger)
         .error(
             org.mockito.ArgumentMatchers.any(RuntimeException.class),
@@ -117,7 +117,7 @@ public class AnalyticsLifecycleCallbacksAttributionTest {
   }
 
   // -------------------------------------------------------------------------
-  // REG2 — without attribution, lifecycle events fire synchronously; no attribution call
+  // without attribution, lifecycle events fire synchronously; no attribution call
   // -------------------------------------------------------------------------
 
   /**

--- a/analytics/src/test/java/io/freshpaint/android/AnalyticsTest.java
+++ b/analytics/src/test/java/io/freshpaint/android/AnalyticsTest.java
@@ -825,7 +825,7 @@ public class AnalyticsTest {
                 new TestUtils.NoDescriptionMatcher<TrackPayload>() {
                   @Override
                   public boolean matches(TrackPayload payload) {
-                    return payload.event().equals("app_install")
+                    return payload.event().equals("Application Installed")
                         && //
                         payload.properties().containsKey("install_timestamp")
                         && //
@@ -833,12 +833,12 @@ public class AnalyticsTest {
                         && //
                         payload.properties().containsKey("os_version")
                         && //
-                        payload.properties().containsKey("app_version");
+                        payload.properties().containsKey("version");
                   }
                 }));
 
     callback.get().onCreate(mockLifecycleOwner);
-    verifyNoMoreInteractions(integration); // app_install is not fired twice
+    verifyNoMoreInteractions(integration); // Application Installed is not fired twice
   }
 
   @Test

--- a/analytics/src/test/java/io/freshpaint/android/AttributionMiddlewareTest.java
+++ b/analytics/src/test/java/io/freshpaint/android/AttributionMiddlewareTest.java
@@ -35,15 +35,6 @@ import java.util.Date;
 import java.util.LinkedHashMap;
 import org.junit.Test;
 
-/**
- * Pure JVM unit tests for {@link AttributionMiddleware}.
- *
- * <p>No Robolectric — Robolectric 3.5 is incompatible with Java 17. {@link AttributionMiddleware}
- * has no real Android dependency; it only reads from {@link AnalyticsContext.Device} (a {@link
- * ValueMap} / {@link LinkedHashMap} subclass) and calls {@code chain.proceed(payload)}. {@link
- * AnalyticsContext} and {@link AnalyticsContext.Device} are constructed via their package-private
- * map-based constructors, which are accessible from this package.
- */
 public class AttributionMiddlewareTest {
 
   // ---------------------------------------------------------------------------
@@ -92,7 +83,7 @@ public class AttributionMiddlewareTest {
   // ---------------------------------------------------------------------------
 
   /**
-   * M2 fix: source device has gaid + limit_ad_tracking=false + context id → payload device must
+   * source device has gaid + limit_ad_tracking=false + context id → payload device must
    * receive all three values, including {@code "id"}.
    */
   @Test
@@ -121,7 +112,7 @@ public class AttributionMiddlewareTest {
     assertThat(resultDevice).isNotNull();
     assertThat(resultDevice).containsEntry("advertisingId", "test-gaid-1234");
     assertThat(resultDevice).containsEntry("limit_ad_tracking", false);
-    // M2: context device id must also be propagated
+    // context device id must also be propagated
     assertThat(resultDevice).containsEntry("id", "test-device-id");
   }
 
@@ -161,7 +152,7 @@ public class AttributionMiddlewareTest {
   }
 
   /**
-   * When a track event carries {@code limit_ad_tracking} in properties (as {@code app_install}
+   * When a track event carries {@code limit_ad_tracking} in properties (as {@code Application Installed}
    * does) but the live device map has since been updated (e.g. GAID finished), properties must
    * match {@code context.device.limit_ad_tracking} so the payload is self-consistent.
    */
@@ -181,7 +172,7 @@ public class AttributionMiddlewareTest {
 
     TrackPayload trackPayload =
         new TrackPayload.Builder()
-            .event("app_install")
+            .event("Application Installed")
             .anonymousId("anon")
             .timestamp(new Date(0))
             .context(payloadContext)
@@ -218,7 +209,7 @@ public class AttributionMiddlewareTest {
 
     TrackPayload trackPayload =
         new TrackPayload.Builder()
-            .event("app_install")
+            .event("Application Installed")
             .anonymousId("anon")
             .timestamp(new Date(0))
             .context(payloadContext)
@@ -247,7 +238,7 @@ public class AttributionMiddlewareTest {
 
     TrackPayload trackPayload =
         new TrackPayload.Builder()
-            .event("app_install")
+            .event("Application Installed")
             .anonymousId("anon")
             .timestamp(new Date(0))
             .context(payloadContext)
@@ -362,7 +353,7 @@ public class AttributionMiddlewareTest {
   }
 
   // ---------------------------------------------------------------------------
-  // AC5 — android_id enrichment
+  // android_id enrichment
   // ---------------------------------------------------------------------------
 
   /**
@@ -425,7 +416,7 @@ public class AttributionMiddlewareTest {
   }
 
   // ---------------------------------------------------------------------------
-  // AC6 — android_id does not conflict with context id or gaid
+  // android_id does not conflict with context id or gaid
   // ---------------------------------------------------------------------------
 
   /**
@@ -463,7 +454,7 @@ public class AttributionMiddlewareTest {
   }
 
   // ---------------------------------------------------------------------------
-  // AC1 (rev 2) — collectDeviceID=false suppresses android_id
+  // collectDeviceID=false suppresses android_id
   // ---------------------------------------------------------------------------
 
   /**
@@ -483,7 +474,7 @@ public class AttributionMiddlewareTest {
   }
 
   // ---------------------------------------------------------------------------
-  // AC2 — Device.putAndroidId() placeholder filtering
+  // Device.putAndroidId() placeholder filtering
   // (Pure-JVM tests: Device is a LinkedHashMap subclass, no Robolectric required.
   // Long-term home is AnalyticsContextTest once Robolectric is upgraded — FU1.)
   // ---------------------------------------------------------------------------

--- a/analytics/src/test/java/io/freshpaint/android/DeepLinkAttributionManagerTest.java
+++ b/analytics/src/test/java/io/freshpaint/android/DeepLinkAttributionManagerTest.java
@@ -63,13 +63,13 @@ public class DeepLinkAttributionManagerTest {
     Map<String, Object> stored = DeepLinkAttributionManager.getStoredProperties(prefs, T0);
     for (String id : AttributionConstants.CLICK_IDS) {
       assertThat(stored).containsEntry("$" + id, "val_" + id);
-      // AC3: each has a creation_time
+      // each has a creation_time
       assertThat(stored).containsKey("$" + id + "_creation_time");
     }
   }
 
   // -------------------------------------------------------------------------
-  // AC3: creation_time set to now on first store
+  // creation_time set to now on first store
   // -------------------------------------------------------------------------
 
   @Test
@@ -85,7 +85,7 @@ public class DeepLinkAttributionManagerTest {
   }
 
   // -------------------------------------------------------------------------
-  // gacid → $gclid_campaign_id (legacy when no gclid/wbraid/gbraid), and matching
+  // gacid → $gclid_campaign_id (legacy when no gclid/wbraid/gbraid) and matching
   // $wbraid_campaign_id / $gbraid_campaign_id when those click ids are present
   // -------------------------------------------------------------------------
 
@@ -173,7 +173,7 @@ public class DeepLinkAttributionManagerTest {
   }
 
   // -------------------------------------------------------------------------
-  // AC5: Facebook special fields
+  // Facebook special fields
   // -------------------------------------------------------------------------
 
   @Test
@@ -212,7 +212,7 @@ public class DeepLinkAttributionManagerTest {
   }
 
   // -------------------------------------------------------------------------
-  // AC6: deduplication — same value preserves creation_time
+  // deduplication — same value preserves creation_time
   // -------------------------------------------------------------------------
 
   @Test
@@ -229,7 +229,7 @@ public class DeepLinkAttributionManagerTest {
     assertThat(stored).containsEntry("$gclid_creation_time", T0);
   }
 
-  // AC6: deduplication — different value resets creation_time
+  // deduplication — different value resets creation_time
   @Test
   public void store_differentClickIdValue_updatesCreationTime() {
     Map<String, String> params1 = new LinkedHashMap<>();
@@ -246,7 +246,7 @@ public class DeepLinkAttributionManagerTest {
   }
 
   // -------------------------------------------------------------------------
-  // AC7: click IDs persist after 24 hours (no expiry)
+  // click IDs persist after 24 hours (no expiry)
   // -------------------------------------------------------------------------
 
   @Test
@@ -261,7 +261,7 @@ public class DeepLinkAttributionManagerTest {
   }
 
   // -------------------------------------------------------------------------
-  // AC8: UTM params stored
+  // UTM params stored
   // -------------------------------------------------------------------------
 
   @Test
@@ -284,7 +284,7 @@ public class DeepLinkAttributionManagerTest {
   }
 
   // -------------------------------------------------------------------------
-  // AC9: UTM expiry
+  // UTM expiry
   // -------------------------------------------------------------------------
 
   @Test

--- a/analytics/src/test/java/io/freshpaint/android/FreshpaintInstallEventTest.java
+++ b/analytics/src/test/java/io/freshpaint/android/FreshpaintInstallEventTest.java
@@ -48,11 +48,11 @@ import org.junit.Before;
 import org.junit.Test;
 
 /**
- * Unit tests for the {@code app_install} first-open event fired from {@link
+ * Unit tests for the {@code Application Installed} first-open event fired from {@link
  * Freshpaint#trackApplicationLifecycleEvents()}.
  *
  * <p>These tests use pure JVM + Mockito (no Robolectric) following the pattern established in
- * FRP-41. A capture {@link Middleware} intercepts payloads synchronously before they reach the
+ * A capture {@link Middleware} intercepts payloads synchronously before they reach the
  * Android Handler, allowing direct assertions on dispatched events.
  */
 public class FreshpaintInstallEventTest {
@@ -134,22 +134,22 @@ public class FreshpaintInstallEventTest {
   }
 
   // -------------------------------------------------------------------------
-  // AC1 — First launch fires app_install
+  // First launch fires Application Installed
   // -------------------------------------------------------------------------
 
   @Test
-  public void firstLaunchFiresAppInstall() {
+  public void firstLaunchFiresApplicationInstalled() {
     // previousBuild defaults to -1 (key absent) → first install
     Freshpaint fp = buildFreshpaint(true);
     fp.trackApplicationLifecycleEvents();
 
     assertThat(tracksOf(captured)).hasSize(1);
-    assertThat(tracksOf(captured).get(0).event()).isEqualTo("app_install");
+    assertThat(tracksOf(captured).get(0).event()).isEqualTo("Application Installed");
   }
 
-  // AC1 — Required fields present in app_install payload
+  // Required fields present in Application Installed payload
   @Test
-  public void firstLaunchAppInstallHasAllRequiredFields() {
+  public void firstLaunchApplicationInstalledHasAllRequiredFields() {
     Freshpaint fp = buildFreshpaint(true);
     fp.trackApplicationLifecycleEvents();
 
@@ -157,11 +157,12 @@ public class FreshpaintInstallEventTest {
     assertThat(props).containsKey("install_timestamp");
     assertThat(props).containsKey("limit_ad_tracking");
     assertThat(props).containsKey("os_version");
-    assertThat(props).containsKey("app_version");
+    assertThat(props).containsKey("version");
+    assertThat(props).containsKey("build");
     // advertisingId is omitted when not yet resolved; see advertisingIdAbsentWhenNotResolved
   }
 
-  // AC5 — install_timestamp is a valid ISO 8601 string
+  // install_timestamp is a valid ISO 8601 string
   @Test
   public void installTimestampIsIso8601() {
     Freshpaint fp = buildFreshpaint(true);
@@ -172,21 +173,21 @@ public class FreshpaintInstallEventTest {
     assertThat(ts.toString()).matches("\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}.*");
   }
 
-  // AC6 — app_version matches the mocked PackageInfo
+  // version matches the mocked PackageInfo
   @Test
   public void appVersionMatchesPackageInfo() {
     Freshpaint fp = buildFreshpaint(true);
     fp.trackApplicationLifecycleEvents();
 
-    assertThat(tracksOf(captured).get(0).properties().get("app_version")).isEqualTo("1.0.0");
+    assertThat(tracksOf(captured).get(0).properties().get("version")).isEqualTo("1.0.0");
   }
 
   // -------------------------------------------------------------------------
-  // AC2 — Second launch does NOT fire app_install
+  // Second launch does NOT fire Application Installed
   // -------------------------------------------------------------------------
 
   @Test
-  public void secondLaunchDoesNotFireAppInstall() {
+  public void secondLaunchDoesNotFireApplicationInstalled() {
     // Simulate first_open_tracked already set by a prior launch
     fakePrefs.store.put("first_open_tracked", true);
 
@@ -197,7 +198,7 @@ public class FreshpaintInstallEventTest {
   }
 
   // -------------------------------------------------------------------------
-  // AC3 — App upgrade fires Application Updated, not app_install
+  // App upgrade fires Application Updated, not Application Installed
   // -------------------------------------------------------------------------
 
   @Test
@@ -214,7 +215,7 @@ public class FreshpaintInstallEventTest {
   }
 
   @Test
-  public void appUpgradeDoesNotFireAppInstall() {
+  public void appUpgradeDoesNotFireApplicationInstalled() {
     fakePrefs.store.put("build", 0);
     fakePrefs.store.put("version", "0.9.0");
 
@@ -222,16 +223,16 @@ public class FreshpaintInstallEventTest {
     fp.trackApplicationLifecycleEvents();
 
     boolean appInstallFired =
-        tracksOf(captured).stream().anyMatch(p -> "app_install".equals(p.event()));
+        tracksOf(captured).stream().anyMatch(p -> "Application Installed".equals(p.event()));
     assertThat(appInstallFired).isFalse();
   }
 
   // -------------------------------------------------------------------------
-  // AC4 — trackFirstOpen=false suppresses app_install
+  // trackFirstOpen=false suppresses Application Installed
   // -------------------------------------------------------------------------
 
   @Test
-  public void trackFirstOpenFalseSuppressesAppInstall() {
+  public void trackFirstOpenFalseSuppressesApplicationInstalled() {
     Freshpaint fp = buildFreshpaint(false); // trackFirstOpen = false
     fp.trackApplicationLifecycleEvents();
 
@@ -239,21 +240,7 @@ public class FreshpaintInstallEventTest {
   }
 
   // -------------------------------------------------------------------------
-  // AC9 — "Application Installed" is never tracked
-  // -------------------------------------------------------------------------
-
-  @Test
-  public void applicationInstalledStringNeverTracked() {
-    Freshpaint fp = buildFreshpaint(true);
-    fp.trackApplicationLifecycleEvents();
-
-    boolean legacyFired =
-        tracksOf(captured).stream().anyMatch(p -> "Application Installed".equals(p.event()));
-    assertThat(legacyFired).isFalse();
-  }
-
-  // -------------------------------------------------------------------------
-  // AC10 — first_open_tracked written atomically with VERSION_KEY/BUILD_KEY
+  // first_open_tracked written atomically with VERSION_KEY/BUILD_KEY
   // -------------------------------------------------------------------------
 
   @Test
@@ -304,7 +291,7 @@ public class FreshpaintInstallEventTest {
   /**
    * Calling {@link Freshpaint#reset()} must NOT remove {@code first_open_tracked}. If the key were
    * cleared on reset, a subsequent {@link Freshpaint#trackApplicationLifecycleEvents()} call would
-   * re-fire {@code app_install}, double-counting the install in MMP backends.
+   * re-fire {@code Application Installed}, double-counting the install in MMP backends.
    */
   @Test
   public void resetPreservesFirstOpenTrackedKey() {
@@ -389,13 +376,13 @@ public class FreshpaintInstallEventTest {
   }
 
   // -------------------------------------------------------------------------
-  // AC13 — Install Referrer data merged into app_install payload (FRP-44)
+  // Install Referrer data merged into Application Installed payload
   // -------------------------------------------------------------------------
 
   /**
    * When Install Referrer data is pre-populated in SharedPreferences (as
-   * trackAttributionInformation does before trackApplicationLifecycleEvents runs), app_install must
-   * include those fields.
+   * trackAttributionInformation does before trackApplicationLifecycleEvents runs), Application
+   * Installed must include those fields.
    */
   @Test
   public void irDataMergedIntoAppInstallPayload() {
@@ -413,7 +400,7 @@ public class FreshpaintInstallEventTest {
     assertThat(tracksOf(captured)).hasSize(1);
     TrackPayload payload = tracksOf(captured).get(0);
     Properties props = payload.properties();
-    // All attribution fields in context (FRP-71)
+    // All attribution fields in context
     assertThat(props).doesNotContainKey("$gclid");
     assertThat(props).doesNotContainKey("$gclid_creation_time");
     assertThat(props).doesNotContainKey("utm_source");
@@ -428,12 +415,13 @@ public class FreshpaintInstallEventTest {
   }
 
   // -------------------------------------------------------------------------
-  // AC10 (FRP-45) — Deep-link attribution merged into app_install
+  // Deep-link attribution merged into Application Installed
   // -------------------------------------------------------------------------
 
   /**
-   * When a deep link fires before {@code app_install}, both the click ID and UTM params appear in
-   * the {@code app_install} payload when the UTM data is within the 24-hour expiry window.
+   * When a deep link fires before {@code Application Installed}, both the click ID and UTM params
+   * appear in the {@code Application Installed} payload when the UTM data is within the 24-hour
+   * expiry window.
    */
   @Test
   public void appInstall_dlClickIdAndUtm_presentWhenWithinExpiryWindow() {
@@ -449,7 +437,7 @@ public class FreshpaintInstallEventTest {
     assertThat(tracksOf(captured)).hasSize(1);
     TrackPayload payload = tracksOf(captured).get(0);
     Properties props = payload.properties();
-    // All attribution fields in context (FRP-71)
+    // All attribution fields in context
     assertThat(props).doesNotContainKey("$gclid");
     assertThat(props).doesNotContainKey("$gclid_creation_time");
     assertThat(props).doesNotContainKey("utm_source");
@@ -459,8 +447,9 @@ public class FreshpaintInstallEventTest {
   }
 
   /**
-   * Click IDs persist indefinitely; UTM params are omitted from {@code app_install} once they have
-   * expired (older than 24 hours at the time {@code trackApplicationLifecycleEvents} runs).
+   * Click IDs persist indefinitely; UTM params are omitted from {@code Application Installed} once
+   * they have expired (older than 24 hours at the time {@code trackApplicationLifecycleEvents}
+   * runs).
    */
   @Test
   public void appInstall_dlClickIdPersists_utmOmittedAfterExpiry() {
@@ -476,7 +465,7 @@ public class FreshpaintInstallEventTest {
     assertThat(tracksOf(captured)).hasSize(1);
     TrackPayload payload = tracksOf(captured).get(0);
     Properties props = payload.properties();
-    // Click ID in context and persists indefinitely (FRP-71)
+    // Click ID in context and persists indefinitely
     assertThat(props).doesNotContainKey("$gclid");
     assertThat(payload.context().get("$gclid")).isEqualTo("DL_GCLID_123");
     // UTM expired — absent from both properties and context
@@ -485,8 +474,8 @@ public class FreshpaintInstallEventTest {
   }
 
   /**
-   * DL click IDs must appear in {@code app_install} even when the IR prefs are also populated —
-   * confirming DL data overwrites IR data for overlapping keys.
+   * DL click IDs must appear in {@code Application Installed} even when the IR prefs are also
+   * populated — confirming DL data overwrites IR data for overlapping keys.
    */
   @Test
   public void appInstallDlOverwritesIrForOverlappingKeys() {
@@ -505,7 +494,7 @@ public class FreshpaintInstallEventTest {
 
     TrackPayload payload = tracksOf(captured).get(0);
     Properties props = payload.properties();
-    // Click IDs in context, not properties (FRP-71)
+    // Click IDs in context, not properties
     assertThat(props).doesNotContainKey("$gclid");
     assertThat(props).doesNotContainKey("$gclid_creation_time");
     // DL value wins in context
@@ -514,7 +503,7 @@ public class FreshpaintInstallEventTest {
   }
 
   // -------------------------------------------------------------------------
-  // AC11 (FRP-45) — isFirstOpenTracked() and getDeepLinkAttributionProperties()
+  // isFirstOpenTracked() and getDeepLinkAttributionProperties()
   // -------------------------------------------------------------------------
 
   /** {@code isFirstOpenTracked()} must return false when the key is absent. */
@@ -551,12 +540,12 @@ public class FreshpaintInstallEventTest {
   }
 
   // -------------------------------------------------------------------------
-  // AC3/AC4 — android_id in app_install payload
+  // android_id in Application Installed payload
   // -------------------------------------------------------------------------
 
   /**
    * When the device context has a valid {@code android_id}, it must appear in the {@code
-   * app_install} event properties.
+   * Application Installed} event properties.
    */
   @Test
   public void appInstall_containsAndroidId_whenPresent() {
@@ -614,14 +603,14 @@ public class FreshpaintInstallEventTest {
     fp.trackApplicationLifecycleEvents();
 
     assertThat(tracksOf(captured)).hasSize(1);
-    assertThat(tracksOf(captured).get(0).event()).isEqualTo("app_install");
+    assertThat(tracksOf(captured).get(0).event()).isEqualTo("Application Installed");
     assertThat(tracksOf(captured).get(0).properties())
         .containsEntry("android_id", "real-android-id-xyz");
   }
 
   /**
    * When the device context has no valid android_id (null), the {@code android_id} key must be
-   * absent from the {@code app_install} event properties.
+   * absent from the {@code Application Installed} event properties.
    */
   @Test
   public void appInstall_doesNotContainAndroidId_whenNull() {

--- a/analytics/src/test/java/io/freshpaint/android/InstallReferrerManagerTest.java
+++ b/analytics/src/test/java/io/freshpaint/android/InstallReferrerManagerTest.java
@@ -103,7 +103,7 @@ public class InstallReferrerManagerTest {
   }
 
   // -------------------------------------------------------------------------
-  // AC1 — UTM params parsed correctly
+  // UTM params parsed correctly
   // -------------------------------------------------------------------------
 
   @Test
@@ -148,7 +148,7 @@ public class InstallReferrerManagerTest {
   }
 
   // -------------------------------------------------------------------------
-  // AC3 — fp_click_id stored without $ prefix
+  // fp_click_id stored without $ prefix
   // -------------------------------------------------------------------------
 
   @Test
@@ -190,7 +190,7 @@ public class InstallReferrerManagerTest {
   }
 
   // -------------------------------------------------------------------------
-  // AC5 — Facebook special fields
+  // Facebook special fields
   // -------------------------------------------------------------------------
 
   @Test
@@ -207,7 +207,7 @@ public class InstallReferrerManagerTest {
   }
 
   // -------------------------------------------------------------------------
-  // AC6 — FEATURE_NOT_SUPPORTED → graceful skip
+  // FEATURE_NOT_SUPPORTED → graceful skip
   // -------------------------------------------------------------------------
 
   @Test
@@ -222,7 +222,7 @@ public class InstallReferrerManagerTest {
   }
 
   // -------------------------------------------------------------------------
-  // AC7 — SERVICE_UNAVAILABLE → graceful skip
+  // SERVICE_UNAVAILABLE → graceful skip
   // -------------------------------------------------------------------------
 
   @Test
@@ -237,7 +237,7 @@ public class InstallReferrerManagerTest {
   }
 
   // -------------------------------------------------------------------------
-  // AC8 — DEVELOPER_ERROR → graceful skip
+  // DEVELOPER_ERROR → graceful skip
   // -------------------------------------------------------------------------
 
   @Test
@@ -251,7 +251,7 @@ public class InstallReferrerManagerTest {
   }
 
   // -------------------------------------------------------------------------
-  // AC9 — Timeout → no hang, endConnection() called
+  // Timeout → no hang, endConnection() called
   // -------------------------------------------------------------------------
 
   @Test(timeout = 6_000) // fails if test hangs beyond 6 s
@@ -268,7 +268,7 @@ public class InstallReferrerManagerTest {
   }
 
   // -------------------------------------------------------------------------
-  // AC10 — collectAndStore() never throws (outer exception contract)
+  // collectAndStore() never throws (outer exception contract)
   // (The NoClassDefFoundError path is verified by code inspection since the library
   // cannot be removed from the test classpath at runtime. This test verifies the outer
   // catch is in place by triggering an internal NPE via a mock Context.)
@@ -289,7 +289,7 @@ public class InstallReferrerManagerTest {
   }
 
   // -------------------------------------------------------------------------
-  // AC10 (direct) — NoClassDefFoundError path in collectAndStore()
+  // NoClassDefFoundError path in collectAndStore()
   // Uses mockStatic to simulate the installreferrer library being absent at
   // runtime by making InstallReferrerClient.newBuilder() throw NoClassDefFoundError.
   // -------------------------------------------------------------------------
@@ -317,7 +317,7 @@ public class InstallReferrerManagerTest {
   }
 
   // -------------------------------------------------------------------------
-  // AC11 — Dedup: same click ID value does NOT update _creation_time
+  // Dedup: same click ID value does NOT update _creation_time
   // -------------------------------------------------------------------------
 
   @Test
@@ -344,7 +344,7 @@ public class InstallReferrerManagerTest {
   }
 
   // -------------------------------------------------------------------------
-  // AC12 — Dedup: different click ID value DOES update _creation_time
+  // Dedup: different click ID value DOES update _creation_time
   // -------------------------------------------------------------------------
 
   @Test
@@ -370,7 +370,7 @@ public class InstallReferrerManagerTest {
   }
 
   // -------------------------------------------------------------------------
-  // AC14 — Referrer timestamps stored correctly
+  // Referrer timestamps stored correctly
   // -------------------------------------------------------------------------
 
   @Test
@@ -385,7 +385,7 @@ public class InstallReferrerManagerTest {
   }
 
   // -------------------------------------------------------------------------
-  // AC15 — Raw referrer string stored
+  // Raw referrer string stored
   // -------------------------------------------------------------------------
 
   @Test
@@ -400,7 +400,7 @@ public class InstallReferrerManagerTest {
   }
 
   // -------------------------------------------------------------------------
-  // AC16 — Client always disconnected (no service leak)
+  // Client always disconnected (no service leak)
   // -------------------------------------------------------------------------
 
   @Test
@@ -433,7 +433,7 @@ public class InstallReferrerManagerTest {
   }
 
   // -------------------------------------------------------------------------
-  // REG3 — TRACKED_ATTRIBUTION_KEY guard: collectAndStore() is idempotent
+  // TRACKED_ATTRIBUTION_KEY guard: collectAndStore() is idempotent
   // -------------------------------------------------------------------------
 
   @Test

--- a/analytics/src/test/java/io/freshpaint/android/MmpIntegrationTest.java
+++ b/analytics/src/test/java/io/freshpaint/android/MmpIntegrationTest.java
@@ -201,14 +201,14 @@ public class MmpIntegrationTest {
   }
 
   // -------------------------------------------------------------------------
-  // IT1 — Full first-open: GAID available + Install Referrer available
+  // Full first-open: GAID available + Install Referrer available
   // -------------------------------------------------------------------------
 
   /**
    * When GAID is resolved and Install Referrer data is pre-populated (as {@code
-   * trackAttributionInformation()} would do on a real device), the {@code app_install} event
-   * contains all attribution fields: {@code advertisingId}, {@code limit_ad_tracking}, {@code
-   * install_referrer}, parsed UTM params, and click IDs.
+   * trackAttributionInformation()} would do on a real device), the {@code Application Installed}
+   * event contains all attribution fields: {@code advertisingId}, {@code limit_ad_tracking},
+   * {@code install_referrer}, parsed UTM params, and click IDs.
    */
   @Test
   public void it1_fullFirstOpen_withGaidAndInstallReferrer() {
@@ -232,7 +232,7 @@ public class MmpIntegrationTest {
 
     assertThat(tracksOf(captured)).hasSize(1);
     TrackPayload event = tracksOf(captured).get(0);
-    assertThat(event.event()).isEqualTo("app_install");
+    assertThat(event.event()).isEqualTo("Application Installed");
 
     Properties props = event.properties();
     assertThat(props.get("advertisingId")).isEqualTo("test-gaid-value");
@@ -240,8 +240,9 @@ public class MmpIntegrationTest {
     // All required fields present
     assertThat(props).containsKey("install_timestamp");
     assertThat(props).containsKey("os_version");
-    assertThat(props).containsKey("app_version");
-    // All attribution fields in context (FRP-71)
+    assertThat(props).containsKey("version");
+    assertThat(props).containsKey("build");
+    // All attribution fields in context
     assertThat(props).doesNotContainKey("$gclid");
     assertThat(props).doesNotContainKey("$gclid_creation_time");
     assertThat(event.context().get("$gclid")).isEqualTo("test-gclid");
@@ -253,13 +254,14 @@ public class MmpIntegrationTest {
   }
 
   // -------------------------------------------------------------------------
-  // IT2 — First-open without Play Services (no GAID, no referrer)
+  // First-open without Play Services (no GAID, no referrer)
   // -------------------------------------------------------------------------
 
   /**
    * When the GAID worker has not run and no Install Referrer data is available (e.g. device has no
-   * Google Play Services), {@code app_install} fires without {@code advertisingId} or referrer
-   * fields. {@code limit_ad_tracking} defaults to {@code true} (conservative / tracking limited).
+   * Google Play Services), {@code Application Installed} fires without {@code advertisingId} or
+   * referrer fields. {@code limit_ad_tracking} defaults to {@code true} (conservative / tracking
+   * limited).
    */
   @Test
   public void it2_firstOpen_withoutPlayServices_noGaidNoReferrer() {
@@ -269,7 +271,7 @@ public class MmpIntegrationTest {
 
     assertThat(tracksOf(captured)).hasSize(1);
     TrackPayload event = tracksOf(captured).get(0);
-    assertThat(event.event()).isEqualTo("app_install");
+    assertThat(event.event()).isEqualTo("Application Installed");
 
     Properties props = event.properties();
     assertThat(props).doesNotContainKey("advertisingId"); // absent, not explicit null
@@ -278,16 +280,17 @@ public class MmpIntegrationTest {
     // Required fields still present
     assertThat(props).containsKey("install_timestamp");
     assertThat(props).containsKey("os_version");
-    assertThat(props).containsKey("app_version");
+    assertThat(props).containsKey("version");
+    assertThat(props).containsKey("build");
   }
 
   // -------------------------------------------------------------------------
-  // IT3 — Organic install: no referrer, no deep link
+  // Organic install: no referrer, no deep link
   // -------------------------------------------------------------------------
 
   /**
-   * A clean organic install with no Install Referrer and no deep link. {@code app_install} fires
-   * with exactly the required fields and no attribution fields.
+   * A clean organic install with no Install Referrer and no deep link. {@code Application Installed}
+   * fires with exactly the required fields and no attribution fields.
    */
   @Test
   public void it3_organicInstall_noReferrerNoDeepLink() {
@@ -296,7 +299,7 @@ public class MmpIntegrationTest {
 
     assertThat(tracksOf(captured)).hasSize(1);
     TrackPayload event = tracksOf(captured).get(0);
-    assertThat(event.event()).isEqualTo("app_install");
+    assertThat(event.event()).isEqualTo("Application Installed");
 
     Properties props = event.properties();
     // No attribution data in properties or context
@@ -310,16 +313,18 @@ public class MmpIntegrationTest {
     assertThat(props).containsKey("install_timestamp");
     assertThat(props).containsKey("limit_ad_tracking");
     assertThat(props).containsKey("os_version");
-    assertThat(props).containsKey("app_version");
+    assertThat(props).containsKey("version");
+    assertThat(props).containsKey("build");
   }
 
   // -------------------------------------------------------------------------
-  // IT4 — Attributed install: deep link with click IDs + UTMs (within window)
+  // Attributed install: deep link with click IDs + UTMs (within window)
   // -------------------------------------------------------------------------
 
   /**
-   * When deep-link attribution data is stored before {@code app_install} fires, the click IDs and
-   * UTM params appear in the event payload — provided the UTM data is within the 24-hour window.
+   * When deep-link attribution data is stored before {@code Application Installed} fires, the click
+   * IDs and UTM params appear in the event payload — provided the UTM data is within the 24-hour
+   * window.
    */
   @Test
   public void it4_attributedInstall_deepLinkClickIdsAndUtm_withinExpiryWindow() {
@@ -337,7 +342,7 @@ public class MmpIntegrationTest {
     assertThat(tracksOf(captured)).hasSize(1);
     TrackPayload payload4 = tracksOf(captured).get(0);
     Properties props4 = payload4.properties();
-    // All attribution fields in context (FRP-71)
+    // All attribution fields in context
     assertThat(props4).doesNotContainKey("$gclid");
     assertThat(props4).doesNotContainKey("$fbclid");
     assertThat(props4).doesNotContainKey("utm_source");
@@ -349,8 +354,8 @@ public class MmpIntegrationTest {
   }
 
   /**
-   * After the 24-hour UTM expiry window, click IDs still appear in {@code app_install} but UTM
-   * params are omitted.
+   * After the 24-hour UTM expiry window, click IDs still appear in {@code Application Installed}
+   * but UTM params are omitted.
    */
   @Test
   public void it4b_attributedInstall_deepLink_clickIdPersists_utmExpiredAfter25h() {
@@ -365,7 +370,7 @@ public class MmpIntegrationTest {
 
     assertThat(tracksOf(captured)).hasSize(1);
     TrackPayload payload4b = tracksOf(captured).get(0);
-    // Click ID in context and persists indefinitely (FRP-71)
+    // Click ID in context and persists indefinitely
     assertThat(payload4b.properties()).doesNotContainKey("$gclid");
     assertThat(payload4b.context().get("$gclid")).isEqualTo("DL_GCLID");
     // UTM expired — absent from both properties and context
@@ -391,7 +396,7 @@ public class MmpIntegrationTest {
 
     assertThat(tracksOf(captured)).hasSize(1);
     TrackPayload payload4c = tracksOf(captured).get(0);
-    // Click ID in context (FRP-71)
+    // Click ID in context
     assertThat(payload4c.properties()).doesNotContainKey("$gclid");
     assertThat(payload4c.context().get("$gclid")).isEqualTo("DL_GCLID");
     // UTM still present at boundary — in context
@@ -413,7 +418,7 @@ public class MmpIntegrationTest {
 
     assertThat(tracksOf(captured)).hasSize(1);
     TrackPayload payload4d = tracksOf(captured).get(0);
-    // Click ID in context (FRP-71)
+    // Click ID in context
     assertThat(payload4d.properties()).doesNotContainKey("$gclid");
     assertThat(payload4d.context().get("$gclid")).isEqualTo("DL_GCLID");
     // UTM expired — absent from both properties and context
@@ -422,12 +427,12 @@ public class MmpIntegrationTest {
   }
 
   // -------------------------------------------------------------------------
-  // IT5 — Sideloaded app: no Install Referrer available
+  // Sideloaded app: no Install Referrer available
   // -------------------------------------------------------------------------
 
   /**
    * When the app is sideloaded (installed via APK, not Play Store), Install Referrer data is never
-   * collected. {@code app_install} fires without referrer fields and does not crash.
+   * collected. {@code Application Installed} fires without referrer fields and does not crash.
    */
   @Test
   public void it5_sideloadedApp_noInstallReferrer_eventFiresWithoutCrash() {
@@ -441,7 +446,7 @@ public class MmpIntegrationTest {
 
     assertThat(tracksOf(captured)).hasSize(1);
     TrackPayload event = tracksOf(captured).get(0);
-    assertThat(event.event()).isEqualTo("app_install");
+    assertThat(event.event()).isEqualTo("Application Installed");
 
     Properties props = event.properties();
     assertThat(props).doesNotContainKey("install_referrer");
@@ -450,17 +455,18 @@ public class MmpIntegrationTest {
     assertThat(props).containsKey("install_timestamp");
     assertThat(props).containsKey("limit_ad_tracking");
     assertThat(props).containsKey("os_version");
-    assertThat(props).containsKey("app_version");
+    assertThat(props).containsKey("version");
+    assertThat(props).containsKey("build");
   }
 
   // -------------------------------------------------------------------------
-  // IT6 — Schema validation: strict PRD alignment
+  // Schema validation: strict PRD alignment
   // -------------------------------------------------------------------------
 
   /**
-   * Strict schema test: {@code app_install} must contain the required fields (install timestamp,
-   * limit ad tracking, OS and app version), each with the correct type, and the event name must
-   * match the current SDK implementation name {@code "app_install"}.
+   * Strict schema test: {@code Application Installed} must contain the required fields (install
+   * timestamp, limit ad tracking, OS version, app version, and build), each with the correct type,
+   * and the event name must be {@code "Application Installed"}.
    */
   @Test
   public void it6_schemaValidation_requiredFieldsWithCorrectTypes() {
@@ -470,11 +476,7 @@ public class MmpIntegrationTest {
     assertThat(tracksOf(captured)).hasSize(1);
     TrackPayload event = tracksOf(captured).get(0);
 
-    // Event name — current implementation uses "app_install"
-    // Note: PRD defines "app_first_open"; this discrepancy is tracked as a carry-forward item
-    // pending stakeholder confirmation. Both alternatives are guarded against the legacy name.
-    assertThat(event.event()).isEqualTo("app_install");
-    assertThat(event.event()).isNotEqualTo("Application Installed"); // legacy Segment name
+    assertThat(event.event()).isEqualTo("Application Installed");
     assertThat(event.event()).isNotEqualTo("Application Opened");
 
     Properties props = event.properties();
@@ -497,23 +499,24 @@ public class MmpIntegrationTest {
         .isInstanceOf(String.class)
         .isEqualTo(Build.VERSION.RELEASE);
 
-    // app_version: matches mocked PackageInfo.versionName
-    assertThat(props.get("app_version")).isEqualTo("1.0.0");
+    // version: matches mocked PackageInfo.versionName; build is String.valueOf(versionCode)
+    assertThat(props.get("version")).isEqualTo("1.0.0");
+    assertThat(props.get("build")).isEqualTo("1");
   }
 
   // -------------------------------------------------------------------------
-  // IT7a — Regression: second launch does not re-fire app_install
+  // Regression: second launch does not re-fire Application Installed
   // -------------------------------------------------------------------------
 
   /**
-   * On the second launch (first_open_tracked already set), {@code app_install} must not fire again.
-   * No track event should be emitted when build and version are unchanged.
+   * On the second launch (first_open_tracked already set), {@code Application Installed} must not
+   * fire again. No track event should be emitted when build and version are unchanged.
    */
   @Test
   public void it7a_regression_secondLaunch_appInstallNotFired() {
     // The actual guard is previousBuild != -1 (build=1 here). The first_open_tracked and
     // version entries are set to reflect a realistic second-launch SharedPreferences state,
-    // not because they are required to suppress app_install on this code path.
+    // not because they are required to suppress Application Installed on this code path.
     fakePrefs.store.put("first_open_tracked", true);
     fakePrefs.store.put("build", 1);
     fakePrefs.store.put("version", "1.0.0");
@@ -522,17 +525,17 @@ public class MmpIntegrationTest {
     fp.trackApplicationLifecycleEvents();
 
     boolean appInstallFired =
-        tracksOf(captured).stream().anyMatch(p -> "app_install".equals(p.event()));
+        tracksOf(captured).stream().anyMatch(p -> "Application Installed".equals(p.event()));
     assertThat(appInstallFired).isFalse();
   }
 
   // -------------------------------------------------------------------------
-  // IT7b — Regression: upgrade fires Application Updated, not app_install
+  // Regression: upgrade fires Application Updated, not Application Installed
   // -------------------------------------------------------------------------
 
   /**
    * An app version upgrade ({@code previousBuild != currentBuild}) must fire exactly {@code
-   * "Application Updated"} and must never fire {@code app_install}.
+   * "Application Updated"} and must never fire {@code Application Installed}.
    */
   @Test
   public void it7b_regression_appUpgrade_firesApplicationUpdatedNotAppInstall() {
@@ -546,16 +549,16 @@ public class MmpIntegrationTest {
     assertThat(tracks).hasSize(1);
     assertThat(tracks.get(0).event()).isEqualTo("Application Updated");
 
-    boolean appInstallFired = tracks.stream().anyMatch(p -> "app_install".equals(p.event()));
+    boolean appInstallFired = tracks.stream().anyMatch(p -> "Application Installed".equals(p.event()));
     assertThat(appInstallFired).isFalse();
   }
 
   // -------------------------------------------------------------------------
-  // IT7c — Regression: Deep Link Opened enrichment
+  // Regression: Deep Link Opened enrichment
   // -------------------------------------------------------------------------
 
   /**
-   * When a deep link opens on the FIRST launch (before {@code app_install} fires, {@code
+   * When a deep link opens on the FIRST launch (before {@code Application Installed} fires, {@code
    * first_open_tracked=false}), {@code Deep Link Opened} must still carry stored attribution in
    * {@code context}. The guard {@code isFirstOpenTracked()} was intentionally removed — the data is
    * available the moment {@code storeDeepLinkAttribution()} returns, and enriching Deep Link Opened
@@ -563,7 +566,7 @@ public class MmpIntegrationTest {
    */
   @Test
   public void it7c_deepLinkOpenedEnrichedOnFirstLaunch_beforeAppInstallFires() {
-    // first_open_tracked is absent — app_install has not yet fired.
+    // first_open_tracked is absent — Application Installed has not yet fired.
     assertThat(fakePrefs.store).doesNotContainKey("first_open_tracked");
 
     Freshpaint fp = buildFreshpaint(emptyContext());
@@ -612,7 +615,8 @@ public class MmpIntegrationTest {
   }
 
   /**
-   * When {@code first_open_tracked=true} (app_install already fired on a previous launch) and a
+   * When {@code first_open_tracked=true} ({@code Application Installed} already fired on a previous
+   * launch) and a
    * deep link is opened, {@code Deep Link Opened} must carry stored attribution ($gclid, UTM, url)
    * in {@code context} only — proving that {@link
    * AnalyticsActivityLifecycleCallbacks#trackDeepLink} enriches via {@link
@@ -624,7 +628,7 @@ public class MmpIntegrationTest {
    */
   @Test
   public void it7c_regression_deepLinkOpenedEnrichedWhenFirstOpenAlreadyTracked() {
-    // Signal that app_install was already tracked on a prior launch.
+    // Signal that Application Installed was already tracked on a prior launch.
     fakePrefs.store.put("first_open_tracked", true);
 
     Freshpaint fp = buildFreshpaint(emptyContext());


### PR DESCRIPTION
## Summary                                                                                                                                                   
  - Reverts install event name `app_install` → `Application Installed` for backward compatibility with existing client pipelines
  - Restores `version` + `build` payload fields (was `app_version` / `build` dropped on MMP branch)
  - Fixes `AttributionMiddleware.APP_INSTALL_EVENT` constant (was still `"app_install"`, silently breaking GAID reconciliation at dispatch)

  All MMP attribution fields intact. Full test suite green.