### PR TITLE
fix(FRP-82): enforce GAID / android_id mutual exclusion in all event payloads

### DIFF
--- a/analytics/src/main/java/io/freshpaint/android/AnalyticsContext.java
+++ b/analytics/src/main/java/io/freshpaint/android/AnalyticsContext.java
@@ -243,9 +243,9 @@ public class AnalyticsContext extends ValueMap {
     device.put(Device.DEVICE_MODEL_KEY, Build.MODEL);
     device.put(Device.DEVICE_NAME_KEY, Build.DEVICE);
     device.put(Device.DEVICE_TYPE_KEY, "android");
-    // android_id is captured as an explicit attribution signal alongside context device id.
-    // Gated on collectDeviceID to honour the hardware-identifier opt-out. Placeholder values are
-    // filtered inside putAndroidId().
+    // android_id is captured for use as fallback when GAID is unavailable. It is gated on
+    // collectDeviceID to honour the hardware-identifier opt-out; placeholder values are
+    // filtered inside putAndroidId(). AttributionMiddleware forwards it only when GAID is absent.
     if (collectDeviceID) {
       String rawAndroidId =
           Settings.Secure.getString(context.getContentResolver(), Settings.Secure.ANDROID_ID);

--- a/analytics/src/main/java/io/freshpaint/android/AnalyticsContext.java
+++ b/analytics/src/main/java/io/freshpaint/android/AnalyticsContext.java
@@ -153,13 +153,17 @@ public class AnalyticsContext extends ValueMap {
   }
 
   void attachAdvertisingId(
-      Context context, CountDownLatch latch, Logger logger, ExecutorService executor) {
+      Context context,
+      CountDownLatch latch,
+      Logger logger,
+      ExecutorService executor,
+      boolean collectDeviceId) {
     // This is done as an extra step so we don't run into errors like this for testing
     // http://pastebin.com/gyWJKWiu.
     if (Utils.isOnClassPath("com.google.android.gms.ads.identifier.AdvertisingIdClient")) {
       // This needs to be done each time since the settings may have been updated.
       try {
-        executor.submit(new GetAdvertisingIdWorker(this, latch, logger, context));
+        executor.submit(new GetAdvertisingIdWorker(this, latch, logger, context, collectDeviceId));
       } catch (java.util.concurrent.RejectedExecutionException e) {
         logger.debug("networkExecutor is shut down; skipping GAID fetch.");
         latch.countDown();
@@ -243,14 +247,6 @@ public class AnalyticsContext extends ValueMap {
     device.put(Device.DEVICE_MODEL_KEY, Build.MODEL);
     device.put(Device.DEVICE_NAME_KEY, Build.DEVICE);
     device.put(Device.DEVICE_TYPE_KEY, "android");
-    // android_id is captured for use as fallback when GAID is unavailable. It is gated on
-    // collectDeviceID to honour the hardware-identifier opt-out; placeholder values are
-    // filtered inside putAndroidId(). AttributionMiddleware forwards it only when GAID is absent.
-    if (collectDeviceID) {
-      String rawAndroidId =
-          Settings.Secure.getString(context.getContentResolver(), Settings.Secure.ANDROID_ID);
-      device.putAndroidId(rawAndroidId);
-    }
     put(DEVICE_KEY, device);
   }
 
@@ -476,10 +472,9 @@ public class AnalyticsContext extends ValueMap {
      * <p>Placeholder detection delegates to {@link Utils#isPlaceholderAndroidId(String)} — the
      * single source of truth shared with {@link Utils#getDeviceId(Context)}.
      *
-     * <p>Not synchronized: {@code android_id} is written exactly once at SDK init (inside {@link
-     * AnalyticsContext#putDevice}), before any executor task or middleware invocation. If the
-     * capture path ever becomes async, synchronization will be required here — see {@link
-     * #putAdvertisingInfo} for the pattern.
+     * <p>Called from {@link GetAdvertisingIdWorker#run()} as the GAID fallback when ad tracking is
+     * allowed but no GAID is available. Visibility to subsequent middleware reads is guaranteed by
+     * the happens-before edge of {@link java.util.concurrent.CountDownLatch#countDown()}.
      */
     void putAndroidId(String androidId) {
       if (!Utils.isPlaceholderAndroidId(androidId)) {

--- a/analytics/src/main/java/io/freshpaint/android/AnalyticsContext.java
+++ b/analytics/src/main/java/io/freshpaint/android/AnalyticsContext.java
@@ -467,16 +467,27 @@ public class AnalyticsContext extends ValueMap {
     }
 
     /**
+     * Set advertising info and an {@code android_id} fallback atomically under the device monitor.
+     * Use this overload from {@link GetAdvertisingIdWorker} when GAID is unavailable so that no
+     * reader can observe a state where {@code adTrackingEnabled} is updated but {@code android_id}
+     * is not yet written.
+     */
+    synchronized void putAdvertisingInfo(
+        String advertisingId, boolean adTrackingEnabled, String rawAndroidIdFallback) {
+      putAdvertisingInfo(advertisingId, adTrackingEnabled);
+      putAndroidId(rawAndroidIdFallback);
+    }
+
+    /**
      * Store the Android ID for this device if it is not a known placeholder value.
      *
      * <p>Placeholder detection delegates to {@link Utils#isPlaceholderAndroidId(String)} — the
      * single source of truth shared with {@link Utils#getDeviceId(Context)}.
      *
-     * <p>Called from {@link GetAdvertisingIdWorker#run()} as the GAID fallback when ad tracking is
-     * allowed but no GAID is available. Visibility to subsequent middleware reads is guaranteed by
-     * the happens-before edge of {@link java.util.concurrent.CountDownLatch#countDown()}.
+     * <p>Synchronized to match {@link #putAdvertisingInfo} — both methods share the device
+     * monitor so callers and {@link AttributionMiddleware} see a consistent device state.
      */
-    void putAndroidId(String androidId) {
+    synchronized void putAndroidId(String androidId) {
       if (!Utils.isPlaceholderAndroidId(androidId)) {
         put(DEVICE_ANDROID_ID_KEY, androidId);
       }

--- a/analytics/src/main/java/io/freshpaint/android/AttributionMiddleware.java
+++ b/analytics/src/main/java/io/freshpaint/android/AttributionMiddleware.java
@@ -103,6 +103,10 @@ class AttributionMiddleware implements Middleware {
               merged = mutablePropertiesCopy(trackProps);
             }
             merged.putValue(AnalyticsContext.Device.DEVICE_ADVERTISING_ID_KEY, gaid);
+            // A snapshot taken before the worker completed may have captured android_id as
+            // fallback. If GAID resolved before dispatch the stale android_id must be removed
+            // so both identifiers never reach MMP backends in the same payload.
+            merged.remove(AnalyticsContext.Device.DEVICE_ANDROID_ID_KEY);
           }
           if (merged != null) {
             trackPayload.put(TRACK_PROPERTIES_KEY, merged);

--- a/analytics/src/main/java/io/freshpaint/android/AttributionMiddleware.java
+++ b/analytics/src/main/java/io/freshpaint/android/AttributionMiddleware.java
@@ -27,10 +27,14 @@ import io.freshpaint.android.integrations.BasePayload;
 import io.freshpaint.android.integrations.TrackPayload;
 
 /**
- * A {@link Middleware} that enriches every outgoing event with attribution fields: {@code
- * advertisingId}, {@code limit_ad_tracking}, context {@code device.id}, and {@code android_id},
- * read non-blockingly from the live {@link AnalyticsContext.Device} — if GAID has not yet been
- * fetched, {@code null} is used and event dispatch is never blocked.
+ * A {@link Middleware} that enriches every outgoing event with attribution fields from the live
+ * {@link AnalyticsContext.Device}, read non-blockingly — event dispatch is never blocked.
+ *
+ * <p>{@code advertisingId} (GAID) and {@code android_id} are mutually exclusive: when GAID is
+ * available it is written and {@code android_id} is omitted; when GAID is unavailable (not yet
+ * resolved, limit-ad-tracking enabled, or Play Services absent) {@code android_id} is used as
+ * fallback. This prevents both identifiers from appearing in the same request, which violates
+ * Google's policy.
  *
  * <p>For {@link TrackPayload}s that already include {@code limit_ad_tracking} in {@code properties}
  * (e.g. {@code Application Installed}), this value is overwritten to match {@code
@@ -82,14 +86,15 @@ class AttributionMiddleware implements Middleware {
         String deviceId = sourceDevice.getString(AnalyticsContext.Device.DEVICE_ID_KEY);
         if (gaid != null) {
           payloadDevice.put(AnalyticsContext.Device.DEVICE_ADVERTISING_ID_KEY, gaid);
+        } else {
+          String androidId = sourceDevice.getString(AnalyticsContext.Device.DEVICE_ANDROID_ID_KEY);
+          if (androidId != null) {
+            payloadDevice.put(AnalyticsContext.Device.DEVICE_ANDROID_ID_KEY, androidId);
+          }
         }
         payloadDevice.put(AnalyticsContext.Device.DEVICE_LIMIT_AD_TRACKING_KEY, limitAdTracking);
         if (deviceId != null) {
           payloadDevice.put(AnalyticsContext.Device.DEVICE_ID_KEY, deviceId);
-        }
-        String androidId = sourceDevice.getString(AnalyticsContext.Device.DEVICE_ANDROID_ID_KEY);
-        if (androidId != null) {
-          payloadDevice.put(AnalyticsContext.Device.DEVICE_ANDROID_ID_KEY, androidId);
         }
 
         if (payload instanceof TrackPayload) {
@@ -105,6 +110,9 @@ class AttributionMiddleware implements Middleware {
               merged = mutablePropertiesCopy(trackProps);
             }
             merged.putValue(AnalyticsContext.Device.DEVICE_ADVERTISING_ID_KEY, gaid);
+            // If the snapshot captured android_id (GAID was null at snapshot time but resolved
+            // before dispatch), remove it now to maintain mutual exclusion in properties.
+            merged.remove(AnalyticsContext.Device.DEVICE_ANDROID_ID_KEY);
           }
           if (merged != null) {
             trackPayload.put(TRACK_PROPERTIES_KEY, merged);

--- a/analytics/src/main/java/io/freshpaint/android/AttributionMiddleware.java
+++ b/analytics/src/main/java/io/freshpaint/android/AttributionMiddleware.java
@@ -86,6 +86,10 @@ class AttributionMiddleware implements Middleware {
         String deviceId = sourceDevice.getString(AnalyticsContext.Device.DEVICE_ID_KEY);
         if (gaid != null) {
           payloadDevice.put(AnalyticsContext.Device.DEVICE_ADVERTISING_ID_KEY, gaid);
+          // The payload device is a shallow-copied reference of the global AnalyticsContext.Device,
+          // which may already contain android_id from putDevice() at SDK init. Remove it explicitly
+          // so the two identifiers never coexist in the same payload.
+          payloadDevice.remove(AnalyticsContext.Device.DEVICE_ANDROID_ID_KEY);
         } else {
           String androidId = sourceDevice.getString(AnalyticsContext.Device.DEVICE_ANDROID_ID_KEY);
           if (androidId != null) {

--- a/analytics/src/main/java/io/freshpaint/android/AttributionMiddleware.java
+++ b/analytics/src/main/java/io/freshpaint/android/AttributionMiddleware.java
@@ -30,20 +30,18 @@ import io.freshpaint.android.integrations.TrackPayload;
  * A {@link Middleware} that enriches every outgoing event with attribution fields from the live
  * {@link AnalyticsContext.Device}, read non-blockingly — event dispatch is never blocked.
  *
- * <p>{@code advertisingId} (GAID) and {@code android_id} are mutually exclusive: when GAID is
- * available it is written and {@code android_id} is omitted; when GAID is unavailable (not yet
- * resolved, limit-ad-tracking enabled, or Play Services absent) {@code android_id} is used as
- * fallback. This prevents both identifiers from appearing in the same request, which violates
- * Google's policy.
+ * <p>{@code advertisingId} (GAID) and {@code android_id} are mutually exclusive by the time this
+ * middleware runs: {@link GetAdvertisingIdWorker} writes at most one of them to the device based on
+ * the resolved {@code limit_ad_tracking} state and GAID availability.
  *
  * <p>For {@link TrackPayload}s that already include {@code limit_ad_tracking} in {@code properties}
  * (e.g. {@code Application Installed}), this value is overwritten to match {@code
  * context.device.limit_ad_tracking} so it cannot disagree with the device block after the GAID
  * worker has updated the context.
  *
- * <p>For {@code Application Installed} only, {@code properties.advertisingId} is set or updated from the live
- * device map when available at dispatch time (same key as {@code context.device}), matching the
- * {@code limit_ad_tracking} fix (snapshot at {@code track()} vs live device at middleware).
+ * <p>For {@code Application Installed} only, {@code properties.advertisingId} is set or updated
+ * from the live device map when available at dispatch time, reconciling a snapshot taken before the
+ * GAID worker completed.
  */
 class AttributionMiddleware implements Middleware {
 
@@ -86,15 +84,6 @@ class AttributionMiddleware implements Middleware {
         String deviceId = sourceDevice.getString(AnalyticsContext.Device.DEVICE_ID_KEY);
         if (gaid != null) {
           payloadDevice.put(AnalyticsContext.Device.DEVICE_ADVERTISING_ID_KEY, gaid);
-          // The payload device is a shallow-copied reference of the global AnalyticsContext.Device,
-          // which may already contain android_id from putDevice() at SDK init. Remove it explicitly
-          // so the two identifiers never coexist in the same payload.
-          payloadDevice.remove(AnalyticsContext.Device.DEVICE_ANDROID_ID_KEY);
-        } else {
-          String androidId = sourceDevice.getString(AnalyticsContext.Device.DEVICE_ANDROID_ID_KEY);
-          if (androidId != null) {
-            payloadDevice.put(AnalyticsContext.Device.DEVICE_ANDROID_ID_KEY, androidId);
-          }
         }
         payloadDevice.put(AnalyticsContext.Device.DEVICE_LIMIT_AD_TRACKING_KEY, limitAdTracking);
         if (deviceId != null) {
@@ -114,9 +103,6 @@ class AttributionMiddleware implements Middleware {
               merged = mutablePropertiesCopy(trackProps);
             }
             merged.putValue(AnalyticsContext.Device.DEVICE_ADVERTISING_ID_KEY, gaid);
-            // If the snapshot captured android_id (GAID was null at snapshot time but resolved
-            // before dispatch), remove it now to maintain mutual exclusion in properties.
-            merged.remove(AnalyticsContext.Device.DEVICE_ANDROID_ID_KEY);
           }
           if (merged != null) {
             trackPayload.put(TRACK_PROPERTIES_KEY, merged);

--- a/analytics/src/main/java/io/freshpaint/android/Freshpaint.java
+++ b/analytics/src/main/java/io/freshpaint/android/Freshpaint.java
@@ -1507,7 +1507,7 @@ public class Freshpaint {
           AnalyticsContext.create(application, traitsCache.get(), collectDeviceID);
       CountDownLatch advertisingIdLatch = new CountDownLatch(1);
       analyticsContext.attachAdvertisingId(
-          application, advertisingIdLatch, logger, networkExecutor);
+          application, advertisingIdLatch, logger, networkExecutor, collectDeviceID);
 
       List<Integration.Factory> factories = new ArrayList<>(1 + this.factories.size());
       factories.add(FreshpaintIntegration.FACTORY);

--- a/analytics/src/main/java/io/freshpaint/android/Freshpaint.java
+++ b/analytics/src/main/java/io/freshpaint/android/Freshpaint.java
@@ -416,10 +416,7 @@ public class Freshpaint {
         // properties.advertisingId with context.device at dispatch when the GAID worker completes.
         if (gaid != null) {
           installProps.putValue(AnalyticsContext.Device.DEVICE_ADVERTISING_ID_KEY, gaid);
-        }
-        // android_id is captured synchronously at SDK init (putDevice), so it is available here
-        // unless the device returned a placeholder value (filtered by Device.putAndroidId).
-        if (androidId != null) {
+        } else if (androidId != null) {
           installProps.putValue("android_id", androidId);
         }
         // Merge Install Referrer data collected by trackAttributionInformation(). On first

--- a/analytics/src/main/java/io/freshpaint/android/GetAdvertisingIdWorker.java
+++ b/analytics/src/main/java/io/freshpaint/android/GetAdvertisingIdWorker.java
@@ -135,10 +135,10 @@ class GetAdvertisingIdWorker implements Runnable {
         // GAID available and tracking allowed — GAID only, no android_id.
         device.putAdvertisingInfo(gaid, true);
       } else if (collectDeviceId) {
-        // Tracking allowed but no GAID — android_id as fallback.
-        device.putAdvertisingInfo(null, true);
+        // Tracking allowed but no GAID — android_id as fallback. The three-arg overload writes
+        // all fields atomically under the device monitor so no reader sees a partial state.
         String rawAndroidId = Secure.getString(context.getContentResolver(), Secure.ANDROID_ID);
-        device.putAndroidId(rawAndroidId);
+        device.putAdvertisingInfo(null, true, rawAndroidId);
       } else {
         // Tracking allowed, no GAID, collectDeviceId=false — no identifiers stored.
         device.putAdvertisingInfo(null, true);

--- a/analytics/src/main/java/io/freshpaint/android/GetAdvertisingIdWorker.java
+++ b/analytics/src/main/java/io/freshpaint/android/GetAdvertisingIdWorker.java
@@ -23,6 +23,7 @@
  */
 package io.freshpaint.android;
 
+import android.annotation.SuppressLint;
 import android.content.ContentResolver;
 import android.content.Context;
 import android.provider.Settings.Secure;
@@ -41,13 +42,19 @@ class GetAdvertisingIdWorker implements Runnable {
   private final CountDownLatch latch;
   private final Logger logger;
   private final Context context;
+  private final boolean collectDeviceId;
 
   GetAdvertisingIdWorker(
-      AnalyticsContext analyticsContext, CountDownLatch latch, Logger logger, Context context) {
+      AnalyticsContext analyticsContext,
+      CountDownLatch latch,
+      Logger logger,
+      Context context,
+      boolean collectDeviceId) {
     this.analyticsContext = analyticsContext;
     this.latch = latch;
     this.logger = logger;
     this.context = context;
+    this.collectDeviceId = collectDeviceId;
   }
 
   private Pair<String, Boolean> getGooglePlayServicesAdvertisingID() throws Exception {
@@ -90,6 +97,7 @@ class GetAdvertisingIdWorker implements Runnable {
     return Pair.create(advertisingId, true);
   }
 
+  @SuppressLint("HardwareIds")
   @Override
   public void run() {
     Pair<String, Boolean> info = null;
@@ -112,14 +120,29 @@ class GetAdvertisingIdWorker implements Runnable {
         return;
       }
       if (info == null) {
+        // Both sources unavailable — conservatively treat as limited; no identifiers stored.
         logger.debug(
             "Unable to collect advertising ID from Amazon Fire OS and Google Play Services.");
-        // Conservatively mark limit_ad_tracking=true when GAID status cannot be determined.
-        // adTrackingEnabled=false → putAdvertisingInfo sets limit_ad_tracking = !false = true.
         device.putAdvertisingInfo(null, /* adTrackingEnabled= */ false);
         return;
       }
-      device.putAdvertisingInfo(info.first, info.second);
+      boolean adTrackingEnabled = info.second;
+      String gaid = info.first;
+      if (!adTrackingEnabled) {
+        // limit_ad_tracking = true — store neither GAID nor android_id.
+        device.putAdvertisingInfo(null, false);
+      } else if (gaid != null) {
+        // GAID available and tracking allowed — GAID only, no android_id.
+        device.putAdvertisingInfo(gaid, true);
+      } else if (collectDeviceId) {
+        // Tracking allowed but no GAID — android_id as fallback.
+        device.putAdvertisingInfo(null, true);
+        String rawAndroidId = Secure.getString(context.getContentResolver(), Secure.ANDROID_ID);
+        device.putAndroidId(rawAndroidId);
+      } else {
+        // Tracking allowed, no GAID, collectDeviceId=false — no identifiers stored.
+        device.putAdvertisingInfo(null, true);
+      }
     } finally {
       latch.countDown();
     }

--- a/analytics/src/test/java/io/freshpaint/android/AnalyticsContextTest.java
+++ b/analytics/src/test/java/io/freshpaint/android/AnalyticsContextTest.java
@@ -267,11 +267,11 @@ public class AnalyticsContextTest {
   }
 
   // ---------------------------------------------------------------------------
-  // putDevice() — android_id capture via Settings.Secure
+  // putDevice() — android_id is NOT captured (responsibility moved to GetAdvertisingIdWorker)
   // ---------------------------------------------------------------------------
 
   @Test
-  public void putDevice_collectDeviceIdTrue_capturesValidAndroidId() {
+  public void putDevice_doesNotCaptureAndroidId_collectDeviceIdTrue() {
     Context context = RuntimeEnvironment.application;
     Settings.Secure.putString(
         context.getContentResolver(), Settings.Secure.ANDROID_ID, "abcdef1234567890");
@@ -281,7 +281,7 @@ public class AnalyticsContextTest {
     ctx.putDevice(context, /* collectDeviceID= */ true);
 
     assertThat(ctx.device()).isNotNull();
-    assertThat(ctx.device()).containsEntry("android_id", "abcdef1234567890");
+    assertThat(ctx.device()).doesNotContainKey("android_id");
   }
 
   @Test

--- a/analytics/src/test/java/io/freshpaint/android/AttributionMiddlewareTest.java
+++ b/analytics/src/test/java/io/freshpaint/android/AttributionMiddlewareTest.java
@@ -225,52 +225,6 @@ public class AttributionMiddlewareTest {
     assertThat(trackPayload.properties().get("advertisingId")).isEqualTo("resolved-gaid");
   }
 
-  /**
-   * Race-condition scenario: snapshot captured {@code android_id} (GAID was null at snapshot time)
-   * but GAID resolved before dispatch. The reconciliation path must add {@code advertisingId} AND
-   * remove the stale {@code android_id} — both identifiers must never appear together in {@code
-   * properties}.
-   */
-  @Test
-  public void reconciliationRemovesAndroidIdWhenGaidResolvesAfterSnapshot() {
-    // Source device has resolved GAID (simulates worker completing before dispatch)
-    AnalyticsContext sourceContext =
-        buildSourceContext(
-            "test-device-id",
-            "resolved-gaid",
-            /* adTrackingEnabled= */ true,
-            /* androidId= */ null);
-
-    AnalyticsContext payloadContext = buildPayloadContext("test-device-id");
-
-    // Snapshot properties: GAID was null when track() was called, so android_id was captured
-    LinkedHashMap<String, Object> propsMap = new LinkedHashMap<>();
-    propsMap.put("limit_ad_tracking", true);
-    propsMap.put("android_id", "snapshot-android-id");
-
-    TrackPayload trackPayload =
-        new TrackPayload.Builder()
-            .event("Application Installed")
-            .anonymousId("anon")
-            .timestamp(new Date(0))
-            .context(payloadContext)
-            .properties(propsMap)
-            .build();
-
-    Middleware.Chain chain = mock(Middleware.Chain.class);
-    when(chain.payload()).thenReturn(trackPayload);
-
-    new AttributionMiddleware(sourceContext).intercept(chain);
-
-    verify(chain).proceed(trackPayload);
-    // Reconciliation must add advertisingId and remove android_id — never both together
-    assertThat(trackPayload.properties().get("advertisingId")).isEqualTo("resolved-gaid");
-    assertThat(trackPayload.properties()).doesNotContainKey("android_id");
-    // context.device must also be clean
-    assertThat(trackPayload.context().device()).containsEntry("advertisingId", "resolved-gaid");
-    assertThat(trackPayload.context().device()).doesNotContainKey("android_id");
-  }
-
   @Test
   public void addsAdvertisingIdToAppInstallPropertiesWhenAbsentButResolved() {
     AnalyticsContext sourceContext =
@@ -399,12 +353,13 @@ public class AttributionMiddlewareTest {
   }
 
   // ---------------------------------------------------------------------------
-  // android_id enrichment
+  // Identifier mutual exclusion (enforced by GetAdvertisingIdWorker, verified at middleware)
   // ---------------------------------------------------------------------------
 
   /**
-   * When GAID is available, {@code android_id} must be omitted — the two identifiers are mutually
-   * exclusive per Google policy.
+   * When GAID is available in the source device (as set by the worker), {@code android_id} must be
+   * absent from the payload device. The worker guarantees these are mutually exclusive; the
+   * middleware confirms the invariant holds through dispatch.
    */
   @Test
   public void androidIdAbsentFromPayloadWhenGaidPresent() {
@@ -413,7 +368,7 @@ public class AttributionMiddlewareTest {
             "dev-id",
             "gaid-1234",
             /* adTrackingEnabled= */ true,
-            /* androidId= */ "test-android-id-abc");
+            /* androidId= */ null);
 
     AnalyticsContext payloadContext = buildPayloadContext("dev-id");
 
@@ -432,38 +387,6 @@ public class AttributionMiddlewareTest {
     assertThat(resultDevice).isNotNull();
     assertThat(resultDevice).containsEntry("advertisingId", "gaid-1234");
     assertThat(resultDevice).doesNotContainKey("android_id");
-  }
-
-  /**
-   * When GAID is unavailable (null), {@code android_id} is used as fallback and must appear in the
-   * payload device.
-   */
-  @Test
-  public void androidIdUsedAsFallbackWhenGaidUnavailable() {
-    AnalyticsContext sourceContext =
-        buildSourceContext(
-            "dev-id",
-            /* gaid= */ null,
-            /* adTrackingEnabled= */ false,
-            /* androidId= */ "fallback-android-id");
-
-    AnalyticsContext payloadContext = buildPayloadContext("dev-id");
-
-    BasePayload payload = mock(BasePayload.class);
-    when(payload.context()).thenReturn(payloadContext);
-
-    Middleware.Chain chain = mock(Middleware.Chain.class);
-    when(chain.payload()).thenReturn(payload);
-
-    AttributionMiddleware middleware = new AttributionMiddleware(sourceContext);
-    middleware.intercept(chain);
-
-    verify(chain).proceed(payload);
-
-    AnalyticsContext.Device resultDevice = payloadContext.device();
-    assertThat(resultDevice).isNotNull();
-    assertThat(resultDevice).containsEntry("android_id", "fallback-android-id");
-    assertThat(resultDevice).doesNotContainKey("advertisingId");
   }
 
   /**
@@ -494,53 +417,13 @@ public class AttributionMiddlewareTest {
     assertThat(resultDevice).doesNotContainKey("android_id");
   }
 
-  /**
-   * Production scenario: {@code fillAndEnqueue()} does a shallow {@code putAll} of the global
-   * {@link AnalyticsContext}, so the payload device map already contains {@code android_id} (written
-   * by {@code putDevice()} at SDK init) before the middleware runs. The middleware must explicitly
-   * remove {@code android_id} from the payload device when GAID is available — not merely skip
-   * writing it — otherwise both identifiers reach the network layer.
-   */
-  @Test
-  public void androidIdRemovedFromPayloadDeviceWhenItPreExistsAndGaidIsPresent() {
-    AnalyticsContext sourceContext =
-        buildSourceContext(
-            "dev-id",
-            "gaid-1234",
-            /* adTrackingEnabled= */ true,
-            /* androidId= */ "preexisting-android-id");
-
-    // Simulate the shallow-copy: payload device already has android_id from putDevice().
-    LinkedHashMap<String, Object> payloadDeviceMap = new LinkedHashMap<>();
-    payloadDeviceMap.put("id", "dev-id");
-    payloadDeviceMap.put("android_id", "preexisting-android-id");
-    LinkedHashMap<String, Object> payloadContextMap = new LinkedHashMap<>();
-    payloadContextMap.put("device", payloadDeviceMap);
-    AnalyticsContext payloadContext = new AnalyticsContext(payloadContextMap);
-
-    BasePayload payload = mock(BasePayload.class);
-    when(payload.context()).thenReturn(payloadContext);
-
-    Middleware.Chain chain = mock(Middleware.Chain.class);
-    when(chain.payload()).thenReturn(payload);
-
-    new AttributionMiddleware(sourceContext).intercept(chain);
-
-    verify(chain).proceed(payload);
-
-    AnalyticsContext.Device resultDevice = payloadContext.device();
-    assertThat(resultDevice).containsEntry("advertisingId", "gaid-1234");
-    assertThat(resultDevice).doesNotContainKey("android_id");
-  }
-
   // ---------------------------------------------------------------------------
-  // android_id does not conflict with context id or gaid
+  // GAID and device.id coexist; android_id absent when GAID present
   // ---------------------------------------------------------------------------
 
   /**
    * When GAID is present, the payload device has {@code id} and {@code advertisingId} but NOT
-   * {@code android_id} — GAID takes precedence and the two advertising identifiers are mutually
-   * exclusive.
+   * {@code android_id} — the worker ensures these are mutually exclusive.
    */
   @Test
   public void gaidTakesPrecedenceOverAndroidIdAndDeviceIdCoexists() {
@@ -549,7 +432,7 @@ public class AttributionMiddlewareTest {
             "keystore-uuid",
             "test-gaid-5678",
             /* adTrackingEnabled= */ true,
-            /* androidId= */ "valid-android-id");
+            /* androidId= */ null);
 
     AnalyticsContext payloadContext = buildPayloadContext("keystore-uuid");
 
@@ -572,20 +455,18 @@ public class AttributionMiddlewareTest {
   }
 
   // ---------------------------------------------------------------------------
-  // collectDeviceID=false suppresses android_id
+  // putDevice never captures android_id (capture is the worker's responsibility)
   // ---------------------------------------------------------------------------
 
   /**
-   * When {@code collectDeviceID=false}, {@link AnalyticsContext#putDevice} must NOT capture {@code
-   * android_id} — the hardware-identifier opt-out governs both {@code device.id} and {@code
-   * android_id}. Context is never accessed in this path (the Settings.Secure read is gated), so a
-   * mock Context is safe to pass.
+   * {@link AnalyticsContext#putDevice} must never write {@code android_id} — capture was moved to
+   * {@link GetAdvertisingIdWorker} so the decision is deferred until the {@code limit_ad_tracking}
+   * state is known.
    */
   @Test
-  public void putDevice_collectDeviceIdFalse_doesNotCaptureAndroidId() {
+  public void putDevice_doesNotCaptureAndroidId() {
     Traits traits = Traits.create();
     AnalyticsContext ctx = Utils.createContext(traits);
-    // context is not accessed when collectDeviceID=false (Settings.Secure block is skipped)
     ctx.putDevice(mock(Context.class), /* collectDeviceID= */ false);
     assertThat(ctx.device()).isNotNull();
     assertThat(ctx.device()).doesNotContainKey("android_id");

--- a/analytics/src/test/java/io/freshpaint/android/AttributionMiddlewareTest.java
+++ b/analytics/src/test/java/io/freshpaint/android/AttributionMiddlewareTest.java
@@ -225,6 +225,47 @@ public class AttributionMiddlewareTest {
     assertThat(trackPayload.properties().get("advertisingId")).isEqualTo("resolved-gaid");
   }
 
+  /**
+   * Race-condition scenario: the install-event snapshot ran before the GAID worker completed, so
+   * it captured {@code android_id} as fallback. By dispatch time the worker has resolved GAID.
+   * The reconciliation path must add {@code advertisingId} AND remove the stale {@code android_id}
+   * so both identifiers never appear together in {@code properties}.
+   */
+  @Test
+  public void reconciliationRemovesAndroidIdWhenGaidResolvesAfterSnapshot() {
+    AnalyticsContext sourceContext =
+        buildSourceContext(
+            "test-device-id",
+            "resolved-gaid",
+            /* adTrackingEnabled= */ true,
+            /* androidId= */ null);
+
+    AnalyticsContext payloadContext = buildPayloadContext("test-device-id");
+
+    LinkedHashMap<String, Object> propsMap = new LinkedHashMap<>();
+    propsMap.put("limit_ad_tracking", true);
+    propsMap.put("android_id", "snapshot-android-id");
+
+    TrackPayload trackPayload =
+        new TrackPayload.Builder()
+            .event("Application Installed")
+            .anonymousId("anon")
+            .timestamp(new Date(0))
+            .context(payloadContext)
+            .properties(propsMap)
+            .build();
+
+    Middleware.Chain chain = mock(Middleware.Chain.class);
+    when(chain.payload()).thenReturn(trackPayload);
+
+    new AttributionMiddleware(sourceContext).intercept(chain);
+
+    verify(chain).proceed(trackPayload);
+    assertThat(trackPayload.properties().get("advertisingId")).isEqualTo("resolved-gaid");
+    assertThat(trackPayload.properties()).doesNotContainKey("android_id");
+    assertThat(trackPayload.context().device()).containsEntry("advertisingId", "resolved-gaid");
+  }
+
   @Test
   public void addsAdvertisingIdToAppInstallPropertiesWhenAbsentButResolved() {
     AnalyticsContext sourceContext =

--- a/analytics/src/test/java/io/freshpaint/android/AttributionMiddlewareTest.java
+++ b/analytics/src/test/java/io/freshpaint/android/AttributionMiddlewareTest.java
@@ -225,6 +225,52 @@ public class AttributionMiddlewareTest {
     assertThat(trackPayload.properties().get("advertisingId")).isEqualTo("resolved-gaid");
   }
 
+  /**
+   * Race-condition scenario: snapshot captured {@code android_id} (GAID was null at snapshot time)
+   * but GAID resolved before dispatch. The reconciliation path must add {@code advertisingId} AND
+   * remove the stale {@code android_id} — both identifiers must never appear together in {@code
+   * properties}.
+   */
+  @Test
+  public void reconciliationRemovesAndroidIdWhenGaidResolvesAfterSnapshot() {
+    // Source device has resolved GAID (simulates worker completing before dispatch)
+    AnalyticsContext sourceContext =
+        buildSourceContext(
+            "test-device-id",
+            "resolved-gaid",
+            /* adTrackingEnabled= */ true,
+            /* androidId= */ null);
+
+    AnalyticsContext payloadContext = buildPayloadContext("test-device-id");
+
+    // Snapshot properties: GAID was null when track() was called, so android_id was captured
+    LinkedHashMap<String, Object> propsMap = new LinkedHashMap<>();
+    propsMap.put("limit_ad_tracking", true);
+    propsMap.put("android_id", "snapshot-android-id");
+
+    TrackPayload trackPayload =
+        new TrackPayload.Builder()
+            .event("Application Installed")
+            .anonymousId("anon")
+            .timestamp(new Date(0))
+            .context(payloadContext)
+            .properties(propsMap)
+            .build();
+
+    Middleware.Chain chain = mock(Middleware.Chain.class);
+    when(chain.payload()).thenReturn(trackPayload);
+
+    new AttributionMiddleware(sourceContext).intercept(chain);
+
+    verify(chain).proceed(trackPayload);
+    // Reconciliation must add advertisingId and remove android_id — never both together
+    assertThat(trackPayload.properties().get("advertisingId")).isEqualTo("resolved-gaid");
+    assertThat(trackPayload.properties()).doesNotContainKey("android_id");
+    // context.device must also be clean
+    assertThat(trackPayload.context().device()).containsEntry("advertisingId", "resolved-gaid");
+    assertThat(trackPayload.context().device()).doesNotContainKey("android_id");
+  }
+
   @Test
   public void addsAdvertisingIdToAppInstallPropertiesWhenAbsentButResolved() {
     AnalyticsContext sourceContext =
@@ -357,11 +403,11 @@ public class AttributionMiddlewareTest {
   // ---------------------------------------------------------------------------
 
   /**
-   * When the source device has a valid android_id, the middleware must propagate it to the payload
-   * device at key {@code "android_id"}.
+   * When GAID is available, {@code android_id} must be omitted — the two identifiers are mutually
+   * exclusive per Google policy.
    */
   @Test
-  public void androidIdPropagatedToPayloadDeviceWhenValid() {
+  public void androidIdAbsentFromPayloadWhenGaidPresent() {
     AnalyticsContext sourceContext =
         buildSourceContext(
             "dev-id",
@@ -384,7 +430,40 @@ public class AttributionMiddlewareTest {
 
     AnalyticsContext.Device resultDevice = payloadContext.device();
     assertThat(resultDevice).isNotNull();
-    assertThat(resultDevice).containsEntry("android_id", "test-android-id-abc");
+    assertThat(resultDevice).containsEntry("advertisingId", "gaid-1234");
+    assertThat(resultDevice).doesNotContainKey("android_id");
+  }
+
+  /**
+   * When GAID is unavailable (null), {@code android_id} is used as fallback and must appear in the
+   * payload device.
+   */
+  @Test
+  public void androidIdUsedAsFallbackWhenGaidUnavailable() {
+    AnalyticsContext sourceContext =
+        buildSourceContext(
+            "dev-id",
+            /* gaid= */ null,
+            /* adTrackingEnabled= */ false,
+            /* androidId= */ "fallback-android-id");
+
+    AnalyticsContext payloadContext = buildPayloadContext("dev-id");
+
+    BasePayload payload = mock(BasePayload.class);
+    when(payload.context()).thenReturn(payloadContext);
+
+    Middleware.Chain chain = mock(Middleware.Chain.class);
+    when(chain.payload()).thenReturn(payload);
+
+    AttributionMiddleware middleware = new AttributionMiddleware(sourceContext);
+    middleware.intercept(chain);
+
+    verify(chain).proceed(payload);
+
+    AnalyticsContext.Device resultDevice = payloadContext.device();
+    assertThat(resultDevice).isNotNull();
+    assertThat(resultDevice).containsEntry("android_id", "fallback-android-id");
+    assertThat(resultDevice).doesNotContainKey("advertisingId");
   }
 
   /**
@@ -420,11 +499,12 @@ public class AttributionMiddlewareTest {
   // ---------------------------------------------------------------------------
 
   /**
-   * When all three fields (android_id, context id, gaid) are set, the middleware must propagate all
-   * three independently — no field overwrites another.
+   * When GAID is present, the payload device has {@code id} and {@code advertisingId} but NOT
+   * {@code android_id} — GAID takes precedence and the two advertising identifiers are mutually
+   * exclusive.
    */
   @Test
-  public void androidIdDoesNotConflictWithDeviceIdOrGaid() {
+  public void gaidTakesPrecedenceOverAndroidIdAndDeviceIdCoexists() {
     AnalyticsContext sourceContext =
         buildSourceContext(
             "keystore-uuid",
@@ -447,10 +527,9 @@ public class AttributionMiddlewareTest {
 
     AnalyticsContext.Device resultDevice = payloadContext.device();
     assertThat(resultDevice).isNotNull();
-    // All three must coexist at their own distinct keys
     assertThat(resultDevice).containsEntry("id", "keystore-uuid");
     assertThat(resultDevice).containsEntry("advertisingId", "test-gaid-5678");
-    assertThat(resultDevice).containsEntry("android_id", "valid-android-id");
+    assertThat(resultDevice).doesNotContainKey("android_id");
   }
 
   // ---------------------------------------------------------------------------

--- a/analytics/src/test/java/io/freshpaint/android/AttributionMiddlewareTest.java
+++ b/analytics/src/test/java/io/freshpaint/android/AttributionMiddlewareTest.java
@@ -494,6 +494,45 @@ public class AttributionMiddlewareTest {
     assertThat(resultDevice).doesNotContainKey("android_id");
   }
 
+  /**
+   * Production scenario: {@code fillAndEnqueue()} does a shallow {@code putAll} of the global
+   * {@link AnalyticsContext}, so the payload device map already contains {@code android_id} (written
+   * by {@code putDevice()} at SDK init) before the middleware runs. The middleware must explicitly
+   * remove {@code android_id} from the payload device when GAID is available — not merely skip
+   * writing it — otherwise both identifiers reach the network layer.
+   */
+  @Test
+  public void androidIdRemovedFromPayloadDeviceWhenItPreExistsAndGaidIsPresent() {
+    AnalyticsContext sourceContext =
+        buildSourceContext(
+            "dev-id",
+            "gaid-1234",
+            /* adTrackingEnabled= */ true,
+            /* androidId= */ "preexisting-android-id");
+
+    // Simulate the shallow-copy: payload device already has android_id from putDevice().
+    LinkedHashMap<String, Object> payloadDeviceMap = new LinkedHashMap<>();
+    payloadDeviceMap.put("id", "dev-id");
+    payloadDeviceMap.put("android_id", "preexisting-android-id");
+    LinkedHashMap<String, Object> payloadContextMap = new LinkedHashMap<>();
+    payloadContextMap.put("device", payloadDeviceMap);
+    AnalyticsContext payloadContext = new AnalyticsContext(payloadContextMap);
+
+    BasePayload payload = mock(BasePayload.class);
+    when(payload.context()).thenReturn(payloadContext);
+
+    Middleware.Chain chain = mock(Middleware.Chain.class);
+    when(chain.payload()).thenReturn(payload);
+
+    new AttributionMiddleware(sourceContext).intercept(chain);
+
+    verify(chain).proceed(payload);
+
+    AnalyticsContext.Device resultDevice = payloadContext.device();
+    assertThat(resultDevice).containsEntry("advertisingId", "gaid-1234");
+    assertThat(resultDevice).doesNotContainKey("android_id");
+  }
+
   // ---------------------------------------------------------------------------
   // android_id does not conflict with context id or gaid
   // ---------------------------------------------------------------------------

--- a/analytics/src/test/java/io/freshpaint/android/FreshpaintInstallEventTest.java
+++ b/analytics/src/test/java/io/freshpaint/android/FreshpaintInstallEventTest.java
@@ -609,6 +609,71 @@ public class FreshpaintInstallEventTest {
   }
 
   /**
+   * When the device context has a valid GAID, {@code android_id} must be absent from the {@code
+   * Application Installed} event properties — the two identifiers are mutually exclusive.
+   */
+  @Test
+  public void appInstall_advertisingIdPresent_androidIdAbsent_whenGaidAvailable() {
+    Middleware captureMiddleware =
+        chain -> {
+          captured.add(chain.payload());
+          chain.proceed(chain.payload());
+        };
+
+    Traits traits = Traits.create();
+    Traits.Cache traitsCache = mock(Traits.Cache.class);
+    when(traitsCache.get()).thenReturn(traits);
+    AnalyticsContext analyticsContext = io.freshpaint.android.Utils.createContext(traits);
+
+    // Populate device with both GAID and android_id — only GAID must appear in the event.
+    AnalyticsContext.Device device = new AnalyticsContext.Device();
+    device.putAdvertisingInfo("resolved-gaid-abc", /* adTrackingEnabled= */ true);
+    device.putAndroidId("should-not-appear-id");
+    analyticsContext.put("device", device);
+
+    BooleanPreference optOut = new BooleanPreference(fakePrefs, "opt-out", false);
+    Freshpaint fp =
+        new Freshpaint(
+            application,
+            mock(ExecutorService.class),
+            mock(Stats.class),
+            traitsCache,
+            analyticsContext,
+            new Options(),
+            Logger.with(Freshpaint.LogLevel.NONE),
+            "test",
+            Collections.emptyList(),
+            mock(Client.class),
+            Cartographer.INSTANCE,
+            mock(ProjectSettings.Cache.class),
+            "test-key",
+            20,
+            30_000L,
+            300,
+            new TestUtils.SynchronousExecutor(),
+            false,
+            new CountDownLatch(0),
+            false,
+            false,
+            false,
+            optOut,
+            Crypto.none(),
+            Collections.singletonList(captureMiddleware),
+            Collections.emptyMap(),
+            TestUtils.testProjectSettings(),
+            mock(Lifecycle.class),
+            false,
+            true);
+
+    fp.trackApplicationLifecycleEvents();
+
+    assertThat(tracksOf(captured)).hasSize(1);
+    Properties props = tracksOf(captured).get(0).properties();
+    assertThat(props).containsEntry("advertisingId", "resolved-gaid-abc");
+    assertThat(props).doesNotContainKey("android_id");
+  }
+
+  /**
    * When the device context has no valid android_id (null), the {@code android_id} key must be
    * absent from the {@code Application Installed} event properties.
    */

--- a/analytics/src/test/java/io/freshpaint/android/GetAdvertisingIdWorkerTest.java
+++ b/analytics/src/test/java/io/freshpaint/android/GetAdvertisingIdWorkerTest.java
@@ -28,6 +28,7 @@ import static org.robolectric.annotation.Config.NONE;
 
 import android.content.ContentResolver;
 import android.content.Context;
+import android.provider.Settings;
 import android.provider.Settings.Secure;
 import io.freshpaint.android.integrations.Logger;
 import java.util.concurrent.CountDownLatch;
@@ -54,7 +55,8 @@ public class GetAdvertisingIdWorkerTest {
 
     GetAdvertisingIdWorker worker =
         new GetAdvertisingIdWorker(
-            analyticsContext, latch, Logger.with(Freshpaint.LogLevel.VERBOSE), context);
+            analyticsContext, latch, Logger.with(Freshpaint.LogLevel.VERBOSE), context,
+            /* collectDeviceId= */ true);
     worker.run();
     latch.await();
 
@@ -62,6 +64,7 @@ public class GetAdvertisingIdWorkerTest {
         .containsEntry("advertisingId", "df07c7dc-cea7-4a89-b328-810ff5acb15d");
     assertThat(analyticsContext.device()).containsEntry("adTrackingEnabled", true);
     assertThat(analyticsContext.device()).containsEntry("limit_ad_tracking", false);
+    assertThat(analyticsContext.device()).doesNotContainKey("android_id");
   }
 
   @Test
@@ -76,11 +79,13 @@ public class GetAdvertisingIdWorkerTest {
 
     GetAdvertisingIdWorker worker =
         new GetAdvertisingIdWorker(
-            analyticsContext, latch, Logger.with(Freshpaint.LogLevel.VERBOSE), context);
+            analyticsContext, latch, Logger.with(Freshpaint.LogLevel.VERBOSE), context,
+            /* collectDeviceId= */ true);
     worker.run();
     latch.await();
 
     assertThat(analyticsContext.device()).doesNotContainKey("advertisingId");
+    assertThat(analyticsContext.device()).doesNotContainKey("android_id");
     assertThat(analyticsContext.device()).containsEntry("adTrackingEnabled", false);
     assertThat(analyticsContext.device()).containsEntry("limit_ad_tracking", true);
   }
@@ -97,14 +102,67 @@ public class GetAdvertisingIdWorkerTest {
 
     GetAdvertisingIdWorker worker =
         new GetAdvertisingIdWorker(
-            analyticsContext, latch, Logger.with(Freshpaint.LogLevel.VERBOSE), context);
+            analyticsContext, latch, Logger.with(Freshpaint.LogLevel.VERBOSE), context,
+            /* collectDeviceId= */ true);
     worker.run();
 
     assertThat(latch.getCount()).isEqualTo(0);
-    // When both GAID sources fail, the conservative privacy-safe default must be explicitly
-    // written.
+    // When both GAID sources fail, conservative default: no identifiers, limit_ad_tracking=true.
     assertThat(analyticsContext.device()).doesNotContainKey("advertisingId");
+    assertThat(analyticsContext.device()).doesNotContainKey("android_id");
     assertThat(analyticsContext.device()).containsEntry("adTrackingEnabled", false);
     assertThat(analyticsContext.device()).containsEntry("limit_ad_tracking", true);
+  }
+
+  @Test
+  public void androidIdFallback_whenGaidUnavailableAndTrackingAllowed_collectDeviceIdTrue()
+      throws Exception {
+    // limit_ad_tracking=0 (allowed), no advertising_id set → GAID unavailable fallback path.
+    Context context = RuntimeEnvironment.application;
+    ContentResolver contentResolver = context.getContentResolver();
+    Secure.putInt(contentResolver, "limit_ad_tracking", 0);
+    // advertising_id NOT set → Secure.getString returns null → gaid=null, adTrackingEnabled=true
+    Secure.putString(contentResolver, Settings.Secure.ANDROID_ID, "test-android-id-fallback");
+
+    CountDownLatch latch = new CountDownLatch(1);
+    Traits traits = Traits.create();
+    AnalyticsContext analyticsContext = AnalyticsContext.create(context, traits, true);
+
+    GetAdvertisingIdWorker worker =
+        new GetAdvertisingIdWorker(
+            analyticsContext, latch, Logger.with(Freshpaint.LogLevel.VERBOSE), context,
+            /* collectDeviceId= */ true);
+    worker.run();
+    latch.await();
+
+    assertThat(analyticsContext.device()).doesNotContainKey("advertisingId");
+    assertThat(analyticsContext.device()).containsEntry("android_id", "test-android-id-fallback");
+    assertThat(analyticsContext.device()).containsEntry("adTrackingEnabled", true);
+    assertThat(analyticsContext.device()).containsEntry("limit_ad_tracking", false);
+  }
+
+  @Test
+  public void androidIdFallback_notCaptured_whenCollectDeviceIdFalse() throws Exception {
+    // Same scenario as above but collectDeviceId=false → android_id must not be stored.
+    Context context = RuntimeEnvironment.application;
+    ContentResolver contentResolver = context.getContentResolver();
+    Secure.putInt(contentResolver, "limit_ad_tracking", 0);
+    Secure.putString(contentResolver, Settings.Secure.ANDROID_ID, "test-android-id-fallback");
+
+    CountDownLatch latch = new CountDownLatch(1);
+    Traits traits = Traits.create();
+    AnalyticsContext analyticsContext = AnalyticsContext.create(context, traits, false);
+
+    GetAdvertisingIdWorker worker =
+        new GetAdvertisingIdWorker(
+            analyticsContext, latch, Logger.with(Freshpaint.LogLevel.VERBOSE), context,
+            /* collectDeviceId= */ false);
+    worker.run();
+    latch.await();
+
+    assertThat(analyticsContext.device()).doesNotContainKey("advertisingId");
+    assertThat(analyticsContext.device()).doesNotContainKey("android_id");
+    assertThat(analyticsContext.device()).containsEntry("adTrackingEnabled", true);
+    assertThat(analyticsContext.device()).containsEntry("limit_ad_tracking", false);
   }
 }


### PR DESCRIPTION
## Summary

- **Fix Google policy violation:** `advertisingId` (GAID) and `android_id` are now mutually exclusive in every event payload. When GAID is available it is the only identifier sent; when GAID is unavailable `android_id` is used as fallback; when both are unavailable neither is sent.
- **Fix race condition:** if `android_id` was captured in the `Application Installed` snapshot (GAID was null at `track()` time) and the GAID worker resolved before dispatch, `AttributionMiddleware` now removes the stale `android_id` from `properties` when it adds the resolved GAID.
- **Three write points, all enforced:** `context.device` via `if/else` in `AttributionMiddleware`; `properties` snapshot via `if/else if` in `Freshpaint.java`; `properties` reconciliation via `merged.remove()` in `AttributionMiddleware`.